### PR TITLE
fix: 🐛 resolve load hooks params

### DIFF
--- a/examples/package/build.config.ts
+++ b/examples/package/build.config.ts
@@ -14,12 +14,11 @@ export default defineConfig({
     },
   },
   transform: {
-    formats: ['es2017'],
     excludes: '**/test/*',
   },
-  // bundle: {
-  //   development: true,
-  //   formats: ['esm', 'es2017'],
-  //   externals: true,
-  // },
+  bundle: {
+    development: true,
+    formats: ['esm', 'es2017'],
+    externals: true,
+  },
 });

--- a/examples/package/build.config.ts
+++ b/examples/package/build.config.ts
@@ -14,11 +14,12 @@ export default defineConfig({
     },
   },
   transform: {
+    formats: ['es2017'],
     excludes: '**/test/*',
   },
-  bundle: {
-    development: true,
-    formats: ['esm', 'es2017'],
-    externals: true,
-  },
+  // bundle: {
+  //   development: true,
+  //   formats: ['esm', 'es2017'],
+  //   externals: true,
+  // },
 });

--- a/packages/pkg/src/loaders/transform.ts
+++ b/packages/pkg/src/loaders/transform.ts
@@ -80,7 +80,7 @@ export default async function runTransform(cfg: TaskConfig, ctx: PkgContext) {
 
     fs.ensureDirSync(dirname(dest));
 
-    const id = (await container.resolveId(files[i].filePath))?.id || files[i].filePath;
+    const id = (await container.resolveId(files[i].filePath))?.id || files[i].absolutePath;
 
     const loadResult = await container.load(id);
 

--- a/packages/pkg/src/plugins/dts.ts
+++ b/packages/pkg/src/plugins/dts.ts
@@ -35,7 +35,7 @@ function dtsPlugin(entry: string, generateTypesForJs?: UserConfig['generateTypes
           || (generateTypesForJs && isEcmascriptOnly(ext, filePath)),
         );
 
-      const dtsFiles = dtsCompile(compileFiles);
+      const dtsFiles = dtsCompile(compileFiles) ?? [];
 
       dtsFiles.forEach((file) => {
         this.emitFile({


### PR DESCRIPTION
- [x] `load` hook requires absolute path as the way rollup plugin does