### PR TITLE
chore: 🤖 speed up generating declaration

### DIFF
--- a/examples/package/src/index.tsx
+++ b/examples/package/src/index.tsx
@@ -4,7 +4,7 @@ const App = () => {
   const [count, setCount] = useState(0);
 
   const addCount = () => {
-    setCount((c: number) => c + 1);
+    setCount((c: number) => c + '1');
   };
 
   return (

--- a/packages/pkg/src/plugins/dts.ts
+++ b/packages/pkg/src/plugins/dts.ts
@@ -13,7 +13,6 @@ const dtsFilter = createFilter(
 );
 
 interface CachedContent extends DtsInputFile {
-  srcCode: string;
   updated?: boolean;
 }
 
@@ -62,6 +61,7 @@ function dtsPlugin(entry: string, generateTypesForJs?: UserConfig['generateTypes
         const compileFiles = compileIds.map((id) => ({
           ext: cachedContents[id].ext,
           filePath: id,
+          srcCode: cachedContents[id].srcCode,
         }));
         dtsFiles = dtsCompile(compileFiles);
       } else {

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -12,7 +12,7 @@ import type { PlainObject } from './types';
 import type {
   DecodedSourceMap,
   RawSourceMap,
-} from '@ampproject/remapping/dist/types/types';
+} from '@ampproject/remapping';
 
 import remapping from '@ampproject/remapping';
 


### PR DESCRIPTION
@ice/pkg generates declarations two times faster after setting `skipLibCheck`.

## Before

```shell
[DTS] Generating declaration files take 5264.9ms
```

## After

```shell
[DTS] Generating declaration files take 2116.65ms
```

But there exists a question: should `defaultTypescriptOptions` be overridden by tsconfig configurations.