### PR TITLE
Fix dev jsxruntimepath

### DIFF
--- a/packages/pkg/src/helpers/getSwcConfig.ts
+++ b/packages/pkg/src/helpers/getSwcConfig.ts
@@ -4,6 +4,8 @@ import { TaskName } from '../types.js';
 import type { UserConfig } from '../types.js';
 import type { Config, ModuleConfig } from '@swc/core';
 
+const __DEV__ = `${process.env.NODE_ENV === 'development'}`;
+
 export const getBundleSwcConfig = (userConfig: UserConfig, taskName: TaskName): Config => {
   const define = stringifyObject(userConfig?.define ?? {});
 
@@ -29,7 +31,7 @@ export const getBundleSwcConfig = (userConfig: UserConfig, taskName: TaskName): 
           globals: {
             vars: {
               // Insert __DEV__ for users, can be overrided too.
-              __DEV__: "process.env.NODE_ENV === 'development'",
+              __DEV__,
               ...define,
             },
           },
@@ -67,7 +69,7 @@ export const getTransformSwcConfig = (userConfig: UserConfig, taskName: TaskName
           globals: {
             vars: {
               // Insert __DEV__ for users, can be overrided too.
-              __DEV__: "process.env.NODE_ENV === 'development'",
+              __DEV__,
               ...define,
             },
           },

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -11,6 +11,8 @@ module.exports = function (context) {
 
   const styleUnitPath = require.resolve('style-unit', requireOptions);
 
+  const jsxRuntimePath = require.resolve('react/jsx-runtime', requireOptions);
+
   return {
     name: 'docusaurus-plugin',
     configureWebpack(config) {
@@ -28,7 +30,7 @@ module.exports = function (context) {
       return {
         resolve: {
           alias: {
-            'react/jsx-runtime': path.resolve(siteDir, 'node_modules/react/jsx-runtime'),
+            'react/jsx-runtime': jsxRuntimePath,
             '@mdx-js/react': mdxReactPath,
             'style-unit': styleUnitPath,
             // FIXME: I am not sure how to resolve the actual output folder


### PR DESCRIPTION
fix `__DEV__` define and `jsx-runtime` not found in monorepo