### PR TITLE
feat: exit process if @swc/helpers is not installed

### DIFF
--- a/packages/pkg/src/loaders/transform.ts
+++ b/packages/pkg/src/loaders/transform.ts
@@ -138,7 +138,8 @@ export default async function runTransform(cfg: TaskLoaderConfig, ctx: PkgContex
   logger.info(`⚡️ Build success in ${timeFrom(transformStart)}`);
 
   if (isTransformDistContainingSWCHelpers && !isSWCHelpersDeclaredInDependency) {
-    logger.warn('⚠️ The transformed dist contains @swc/helpers, please make sure @swc/helpers is installed as a dependency.');
+    logger.error('⚠️ The transformed dist contains @swc/helpers, please make sure @swc/helpers is installed as a dependency.');
+    process.exit(1);
   }
 
   return files.map((file) => ({ ...file, filename: relative(outputDir, file.dest) }));

--- a/packages/plugin-docusaurus/src/doc.mts
+++ b/packages/plugin-docusaurus/src/doc.mts
@@ -46,4 +46,10 @@ export const doc = async (api, options: PluginDocusaurusOptions) => {
       throw new Error('Doc build failed!');
     }
   });
+
+  // If transofrm task failed and main process exit,
+  // then doc process should be killed too
+  process.on('exit', () => {
+    child.kill();
+  });
 };


### PR DESCRIPTION
产物代码中如果存在 @swc/helpers 但是用户未安装，则会在控制台给出 warning 提示。该提示较弱用户可能忽略，现调整为以下策略：
- 控制台提示由 warning 升级为 error
- 直接终止编译和预览任务。用户需手动安装 @swc/helpers 之后才可继续开发