### PR TITLE
fix(plugin-docusaurus): can't use short syntax (<></>) of fragment

### DIFF
--- a/packages/plugin-docusaurus/CHANGELOG.md
+++ b/packages/plugin-docusaurus/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 1.3.3
+
+- [fix] can't use short syntax (<></>) of fragment
+
 ## 1.3.2
 
 - [fix] react resolve error in npm

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg-plugin-docusaurus",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Plugin for component previewing",
   "main": "es2017/index.js",
   "exports": {

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -95,6 +95,7 @@ module.exports = {
       require.resolve('@babel/preset-react'),
       {
         "pragma": "createElement",
+        "pragmaFrag": "Fragment",
         "runtime": "classic"
       },
     ],

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -85,7 +85,7 @@ module.exports = function (context) {
         plugins: [
           new webpack.ProvidePlugin({
             createElement: [path.resolve(siteDir, '.docusaurus', 'hijackCreateElement.js'), 'default'],
-            Fragment: ['react', 'Fragment']
+            Fragment: ['react', 'Fragment'],
           }),
         ],
       };

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -85,6 +85,7 @@ module.exports = function (context) {
         plugins: [
           new webpack.ProvidePlugin({
             createElement: [path.resolve(siteDir, '.docusaurus', 'hijackCreateElement.js'), 'default'],
+            Fragment: ['react', 'Fragment']
           }),
         ],
       };


### PR DESCRIPTION
<></> 默认编译为 React.Fragment，而 React 在 automatic 模式下不再必须引入，因此在预览构建时可能出现 React is not defined 的报错。
现直接将其编译为 Fragment，并通过 webpack provider plugin 直接全局注入