### PR TITLE
fix: some export types was remove in d.ts

### DIFF
--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.4.1-beta.0",
+  "version": "1.4.1",
   "description": "Core service of ice component",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.4.0",
+  "version": "1.4.1-beta.0",
   "description": "Core service of ice component",
   "type": "module",
   "main": "./lib/index.js",
@@ -34,6 +34,7 @@
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/pluginutils": "^4.1.2",
     "@swc/core": "^1.2.121",
+    "@zerollup/ts-transform-paths": "^1.7.18",
     "acorn": "^8.7.0",
     "autoprefixer": "^10.4.2",
     "build-scripts": "^2.0.0",
@@ -52,7 +53,7 @@
     "rollup": "^2.62.0",
     "rollup-plugin-styles": "^4.0.0",
     "rollup-plugin-visualizer": "^5.8.3",
-    "typescript": "^4.9.4"
+    "typescript": "~4.7.4"
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.0.3",

--- a/packages/pkg/src/helpers/defaultSwcConfig.ts
+++ b/packages/pkg/src/helpers/defaultSwcConfig.ts
@@ -3,12 +3,12 @@ import {
   Context,
   TaskName,
   TaskValue,
-  TaskConfig,
   TransformTaskConfig,
   NodeEnvMode,
 } from '../types.js';
-import type { Config, JscConfig, ModuleConfig } from '@swc/core';
+import type { Config, ModuleConfig } from '@swc/core';
 import getDefaultDefineValues from './getDefaultDefineValues.js';
+import formatAliasToTSPathsConfig from './formatAliasToTSPathsConfig.js';
 
 export const getDefaultBundleSwcConfig = (
   bundleTaskConfig: BundleTaskConfig,
@@ -32,7 +32,7 @@ export const getDefaultBundleSwcConfig = (
     jsc: {
       target,
       baseUrl: ctx.rootDir,
-      paths: formatAliasPaths(bundleTaskConfig.alias),
+      paths: formatAliasToTSPathsConfig(bundleTaskConfig.alias),
     },
     minify: false,
     // Always generate map in bundle mode,
@@ -63,7 +63,7 @@ export const getDefaultTransformSwcConfig = (
     jsc: {
       target,
       baseUrl: ctx.rootDir,
-      paths: formatAliasPaths(transformTaskConfig.alias),
+      paths: formatAliasToTSPathsConfig(transformTaskConfig.alias),
       transform: {
         optimizer: {
           globals: {
@@ -83,27 +83,3 @@ export const getDefaultTransformSwcConfig = (
     sourceMaps: transformTaskConfig.sourcemap,
   };
 };
-
-function formatAliasPaths(alias: TaskConfig['alias']) {
-  const paths: JscConfig['paths'] = {};
-
-  Object.entries(alias || {}).forEach(([key, value]) => {
-    const [pathKey, pathValue] = formatPath(key, value);
-    paths[pathKey] = [pathValue];
-  });
-
-  return paths;
-}
-
-function formatPath(key: string, value: string) {
-  if (key.endsWith('$')) {
-    return [key.replace(/\$$/, ''), value];
-  }
-  // abc -> abc/*
-  // abc/ -> abc/*
-  return [addWildcard(key), addWildcard(value)];
-}
-
-function addWildcard(str: string) {
-  return `${str.endsWith('/') ? str : `${str}/`}*`;
-}

--- a/packages/pkg/src/helpers/dts.ts
+++ b/packages/pkg/src/helpers/dts.ts
@@ -36,7 +36,7 @@ const normalizeDtsInput = (file: File): DtsInputFile => {
   };
 };
 
-export function dtsCompile(files: File[], alias: TaskConfig['alias'], rootDir: string): DtsInputFile[] {
+export function dtsCompile(files: File[], alias: TaskConfig['alias']): DtsInputFile[] {
   if (!files.length) {
     return;
   }
@@ -47,7 +47,6 @@ export function dtsCompile(files: File[], alias: TaskConfig['alias'], rootDir: s
     incremental: true,
     emitDeclarationOnly: true,
     skipLibCheck: true,
-    baseUrl: rootDir,
     // jsx: 3,
     lib: ['ES2017', 'DOM'],
     paths: formatAliasToTSPathsConfig(alias),

--- a/packages/pkg/src/helpers/formatAliasToTSPathsConfig.ts
+++ b/packages/pkg/src/helpers/formatAliasToTSPathsConfig.ts
@@ -1,0 +1,25 @@
+import { TaskConfig } from '../types.js';
+
+export default function formatAliasToTSPathsConfig(alias: TaskConfig['alias']) {
+  const paths: { [from: string]: [string] } = {};
+
+  Object.entries(alias || {}).forEach(([key, value]) => {
+    const [pathKey, pathValue] = formatPath(key, value);
+    paths[pathKey] = [pathValue];
+  });
+
+  return paths;
+}
+
+function formatPath(key: string, value: string) {
+  if (key.endsWith('$')) {
+    return [key.replace(/\$$/, ''), value];
+  }
+  // abc -> abc/*
+  // abc/ -> abc/*
+  return [addWildcard(key), addWildcard(value)];
+}
+
+function addWildcard(str: string) {
+  return `${str.endsWith('/') ? str : `${str}/`}*`;
+}

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -50,8 +50,13 @@ export function getRollupOptions(
   rollupOptions.plugins.push(swcPlugin(taskConfig.type, taskConfig.swcCompileOptions));
 
   if (taskConfig.type === 'transform') {
-    rollupOptions.plugins.push(
-      dtsPlugin(rootDir, taskConfig.entry as Record<string, string>, userConfig.generateTypesForJs),
+    rollupOptions.plugins.unshift(
+      dtsPlugin({
+        rootDir,
+        entry: taskConfig.entry as Record<string, string>,
+        generateTypesForJs: userConfig.generateTypesForJs,
+        alias: taskConfig.alias,
+      }),
     );
   } else if (taskConfig.type === 'bundle') {
     const [external, globals] = getExternalsAndGlobals(taskConfig, pkg as PkgJson);

--- a/packages/pkg/src/rollupPlugins/dts.ts
+++ b/packages/pkg/src/rollupPlugins/dts.ts
@@ -67,7 +67,7 @@ function dtsPlugin({
           filePath: id,
           srcCode: cachedContents[id].srcCode,
         }));
-        dtsFiles = dtsCompile(files, alias, rootDir);
+        dtsFiles = dtsCompile(files, alias);
       } else {
         dtsFiles = Object.keys(cachedContents).map((id) => {
           const { updated, ...rest } = cachedContents[id];

--- a/packages/pkg/src/rollupPlugins/dts.ts
+++ b/packages/pkg/src/rollupPlugins/dts.ts
@@ -1,18 +1,30 @@
 import { extname, relative } from 'path';
 import { createFilter } from '@rollup/pluginutils';
-import { dtsCompile, File } from '../helpers/dts.js';
+import { dtsCompile, type File } from '../helpers/dts.js';
+import { getTransformEntryDirs } from '../helpers/getTaskIO.js';
 
 import type { Plugin } from 'rollup';
-import type { UserConfig } from '../types.js';
+import type { TaskConfig, UserConfig } from '../types.js';
 import type { DtsInputFile, FileExt } from '../helpers/dts.js';
-import { getTransformEntryDirs } from '../helpers/getTaskIO.js';
 
 interface CachedContent extends DtsInputFile {
   updated: boolean;
 }
 
+interface DtsPluginOptions {
+  rootDir: string;
+  entry: Record<string, string>;
+  alias: TaskConfig['alias'];
+  generateTypesForJs?: UserConfig['generateTypesForJs'];
+}
+
 // dtsPlugin is used to generate declaration file when transforming
-function dtsPlugin(rootDir: string, entry: Record<string, string>, generateTypesForJs?: UserConfig['generateTypesForJs']): Plugin {
+function dtsPlugin({
+  rootDir,
+  entry,
+  alias,
+  generateTypesForJs,
+}: DtsPluginOptions): Plugin {
   const includeFileRegexps = [/\.m?tsx?$/];
   if (generateTypesForJs) {
     includeFileRegexps.push(/\.m?jsx?$/);
@@ -50,12 +62,12 @@ function dtsPlugin(rootDir: string, entry: Record<string, string>, generateTypes
 
       let dtsFiles: DtsInputFile[];
       if (updatedIds.length) {
-        const compileFiles: File[] = updatedIds.map((id) => ({
+        const files: File[] = updatedIds.map((id) => ({
           ext: cachedContents[id].ext,
           filePath: id,
           srcCode: cachedContents[id].srcCode,
         }));
-        dtsFiles = dtsCompile(compileFiles);
+        dtsFiles = dtsCompile(files, alias, rootDir);
       } else {
         dtsFiles = Object.keys(cachedContents).map((id) => {
           const { updated, ...rest } = cachedContents[id];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,7 @@ importers:
       '@types/babel__core': ^7.1.20
       '@types/fs-extra': ^9.0.13
       '@types/node': ^17.0.2
+      '@zerollup/ts-transform-paths': ^1.7.18
       acorn: ^8.7.0
       autoprefixer: ^10.4.2
       build-scripts: ^2.0.0
@@ -184,7 +185,7 @@ importers:
       rollup-plugin-visualizer: ^5.8.3
       sass: ^1.49.8
       source-map: 0.6.1
-      typescript: ^4.9.4
+      typescript: ~4.7.4
     dependencies:
       '@babel/core': 7.18.6
       '@babel/parser': 7.18.8
@@ -195,6 +196,7 @@ importers:
       '@rollup/plugin-replace': 5.0.1_rollup@2.76.0
       '@rollup/pluginutils': 4.2.1
       '@swc/core': 1.2.211
+      '@zerollup/ts-transform-paths': 1.7.18_typescript@4.7.4
       acorn: 8.7.1
       autoprefixer: 10.4.7_postcss@8.4.14
       build-scripts: 2.0.0
@@ -213,7 +215,7 @@ importers:
       rollup: 2.76.0
       rollup-plugin-styles: 4.0.0_rollup@2.76.0
       rollup-plugin-visualizer: 5.8.3_rollup@2.76.0
-      typescript: 4.9.4
+      typescript: 4.7.4
     devDependencies:
       '@ampproject/remapping': 2.2.0
       '@types/babel__core': 7.1.20
@@ -5438,6 +5440,24 @@ packages:
 
   /@xtuc/long/4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  /@zerollup/ts-helpers/1.7.18_typescript@4.7.4:
+    resolution: {integrity: sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==}
+    peerDependencies:
+      typescript: '>=3.7.2'
+    dependencies:
+      resolve: 1.22.1
+      typescript: 4.7.4
+    dev: false
+
+  /@zerollup/ts-transform-paths/1.7.18_typescript@4.7.4:
+    resolution: {integrity: sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==}
+    peerDependencies:
+      typescript: '>=3.7.2'
+    dependencies:
+      '@zerollup/ts-helpers': 1.7.18_typescript@4.7.4
+      typescript: 4.7.4
+    dev: false
 
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -13147,6 +13167,7 @@ packages:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==, tarball: typescript/download/typescript-4.9.4.tgz}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /typical/4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,7 +292,7 @@ importers:
       unist-util-visit: 2.0.3
     devDependencies:
       '@algolia/client-search': 4.13.1
-      '@ice/pkg': link:../pkg
+      '@ice/pkg': 1.4.0
       '@types/react': 17.0.52
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -309,7 +309,7 @@ importers:
     dependencies:
       rax-compat: 0.1.5_biqbaboplfbrettd7655fr4n2y
     devDependencies:
-      '@ice/pkg': link:../pkg
+      '@ice/pkg': 1.4.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.9.4
@@ -4108,6 +4108,43 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /@ice/pkg/1.4.0:
+    resolution: {integrity: sha512-GHFxwfyWMhPcdOmhyHcRO3Jrvzi5AfPA14YBeRjuUxZIvEvWyp15YLsDBKF2eHpUt7lcsFptsWeN3qenEf+Pdg==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/parser': 7.18.8
+      '@rollup/plugin-commonjs': 21.1.0_rollup@2.76.0
+      '@rollup/plugin-image': 3.0.1_rollup@2.76.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.76.0
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.76.0
+      '@rollup/plugin-replace': 5.0.1_rollup@2.76.0
+      '@rollup/pluginutils': 4.2.1
+      '@swc/core': 1.2.211
+      acorn: 8.7.1
+      autoprefixer: 10.4.7_postcss@8.4.14
+      build-scripts: 2.0.0
+      cac: 6.7.12
+      chokidar: 3.5.3
+      consola: 2.15.3
+      debug: 4.3.4
+      deepmerge: 4.2.2
+      escape-string-regexp: 5.0.0
+      fs-extra: 10.1.0
+      globby: 11.1.0
+      gzip-size: 7.0.0
+      magic-string: 0.25.9
+      picocolors: 1.0.0
+      postcss: 8.4.14
+      rollup: 2.76.0
+      rollup-plugin-styles: 4.0.0_rollup@2.76.0
+      rollup-plugin-visualizer: 5.8.3_rollup@2.76.0
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@iceworks/eslint-plugin-best-practices/0.2.11_boy655tvqsm6op45de6ax7jimi:
     resolution: {integrity: sha512-IsMqWijTyj1c8EBP8oZJhhghz01XUm8hh2AreUvQyi/eCgAcr0MgPXZ94NkXB+1OwCskkiVuXTa+fsooeP0IYA==}
     dependencies:
@@ -4444,7 +4481,6 @@ packages:
       magic-string: 0.25.9
       resolve: 1.22.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-image/3.0.1_rollup@2.76.0:
     resolution: {integrity: sha512-F50Sko4Xcc576x7HG9f3MvJKKnBfSmqfVFWJkJgyIEkI8YxZxux28lDbuy0+GsAK6BFl9Gn+TRXOUgHHJbFh3w==}
@@ -4458,7 +4494,6 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@2.76.0
       mini-svg-data-uri: 1.4.4
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-json/4.1.0_rollup@2.76.0:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
@@ -4467,7 +4502,6 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.76.0
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.76.0:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
@@ -4482,7 +4516,6 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-replace/5.0.1_rollup@2.76.0:
     resolution: {integrity: sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==}
@@ -4496,7 +4529,6 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@2.76.0
       magic-string: 0.26.7
       rollup: 2.76.0
-    dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@2.76.0:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
@@ -4508,7 +4540,6 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/pluginutils/4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -4516,7 +4547,6 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: false
 
   /@rollup/pluginutils/5.0.2_rollup@2.76.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -4531,7 +4561,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 2.76.0
-    dev: false
 
   /@sideway/address/4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -4727,7 +4756,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-android-arm64/1.2.211:
@@ -4736,7 +4764,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-arm64/1.2.211:
@@ -4745,7 +4772,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-x64/1.2.211:
@@ -4754,7 +4780,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-freebsd-x64/1.2.211:
@@ -4763,7 +4788,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.2.211:
@@ -4772,7 +4796,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.2.211:
@@ -4782,7 +4805,6 @@ packages:
     os: [linux]
     libc: [glibc]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl/1.2.211:
@@ -4792,7 +4814,6 @@ packages:
     os: [linux]
     libc: [musl]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu/1.2.211:
@@ -4802,7 +4823,6 @@ packages:
     os: [linux]
     libc: [glibc]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-musl/1.2.211:
@@ -4812,7 +4832,6 @@ packages:
     os: [linux]
     libc: [musl]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.2.211:
@@ -4821,7 +4840,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.2.211:
@@ -4830,7 +4848,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-x64-msvc/1.2.211:
@@ -4839,7 +4856,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core/1.2.211:
@@ -4860,7 +4876,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.211
       '@swc/core-win32-ia32-msvc': 1.2.211
       '@swc/core-win32-x64-msvc': 1.2.211
-    dev: false
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -4972,7 +4987,6 @@ packages:
       cssnano: 5.1.12_postcss@8.4.14
     transitivePeerDependencies:
       - postcss
-    dev: false
 
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -4994,18 +5008,15 @@ packages:
 
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
-    dev: false
 
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
   /@types/estree/0.0.52:
     resolution: {integrity: sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==}
-    dev: false
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: false
 
   /@types/express-serve-static-core/4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
@@ -5144,7 +5155,6 @@ packages:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
       '@types/node': 17.0.45
-    dev: false
 
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -5610,7 +5620,6 @@ packages:
   /ansi-regex/2.1.1:
     resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=, tarball: ansi-regex/download/ansi-regex-2.1.1.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5645,14 +5654,12 @@ packages:
 
   /aproba/1.2.0:
     resolution: {integrity: sha1-aALmJk79GMeQobDVF/DyYnvyyUo=, tarball: aproba/download/aproba-1.2.0.tgz}
-    dev: false
 
   /are-we-there-yet/1.1.7:
     resolution: {integrity: sha1-sVR0qTKtq0/4pQ2a36fk6SbyEUY=, tarball: are-we-there-yet/download/are-we-there-yet-1.1.7.tgz}
     dependencies:
       delegates: 1.0.0
       readable-stream: 2.3.7
-    dev: false
 
   /arg/4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -6016,12 +6023,10 @@ packages:
       npmlog: 4.1.2
       picocolors: 1.0.0
       semver: 7.3.7
-    dev: false
 
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-    dev: false
 
   /builtins/1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
@@ -6057,7 +6062,6 @@ packages:
   /cac/6.7.12:
     resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
     engines: {node: '>=8'}
-    dev: false
 
   /cacheable-request/6.1.0:
     resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==}
@@ -6309,7 +6313,6 @@ packages:
   /code-point-at/1.1.0:
     resolution: {integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=, tarball: code-point-at/download/code-point-at-1.1.0.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /collapse-white-space/1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
@@ -6438,7 +6441,6 @@ packages:
 
   /console-control-strings/1.1.0:
     resolution: {integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=, tarball: console-control-strings/download/console-control-strings-1.1.0.tgz}
-    dev: false
 
   /content-disposition/0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -6839,7 +6841,6 @@ packages:
   /decode-uri-component/0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
-    dev: false
 
   /decompress-response/3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
@@ -6907,7 +6908,6 @@ packages:
 
   /delegates/1.0.0:
     resolution: {integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=, tarball: delegates/download/delegates-1.0.0.tgz}
-    dev: false
 
   /depd/1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -7255,7 +7255,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-android-arm64/0.14.49:
@@ -7264,7 +7263,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-64/0.14.49:
@@ -7273,7 +7271,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.14.49:
@@ -7282,7 +7279,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-64/0.14.49:
@@ -7291,7 +7287,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.14.49:
@@ -7300,7 +7295,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-32/0.14.49:
@@ -7309,7 +7303,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-64/0.14.49:
@@ -7318,7 +7311,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm/0.14.49:
@@ -7327,7 +7319,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.14.49:
@@ -7336,7 +7327,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-mips64le/0.14.49:
@@ -7345,7 +7335,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.14.49:
@@ -7354,7 +7343,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-riscv64/0.14.49:
@@ -7363,7 +7351,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-s390x/0.14.49:
@@ -7372,7 +7359,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-netbsd-64/0.14.49:
@@ -7381,7 +7367,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.14.49:
@@ -7390,7 +7375,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-sunos-64/0.14.49:
@@ -7399,7 +7383,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-32/0.14.49:
@@ -7408,7 +7391,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-64/0.14.49:
@@ -7417,7 +7399,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.14.49:
@@ -7426,7 +7407,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild/0.14.49:
@@ -7455,7 +7435,6 @@ packages:
       esbuild-windows-32: 0.14.49
       esbuild-windows-64: 0.14.49
       esbuild-windows-arm64: 0.14.49
-    dev: false
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -7479,7 +7458,6 @@ packages:
   /escape-string-regexp/5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-    dev: false
 
   /eslint-config-ali/13.1.0_eslint@8.19.0:
     resolution: {integrity: sha512-ZjWrpiKADEmNhtfB64iVN3ejlDS5sS9OZx9+jN3mF+oqaroWqrTPvqQvY472M4ykL0JgT+AqsZdG+kWDqUw/6g==}
@@ -7754,11 +7732,9 @@ packages:
 
   /estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
-    dev: false
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: false
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -7977,7 +7953,6 @@ packages:
   /filter-obj/1.1.0:
     resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /finalhandler/1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -8175,7 +8150,6 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: false
 
   /fs-extra/9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -8238,7 +8212,6 @@ packages:
       string-width: 1.0.2
       strip-ansi: 3.0.1
       wide-align: 1.1.5
-    dev: false
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8443,7 +8416,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       duplexer: 0.1.2
-    dev: false
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -8496,7 +8468,6 @@ packages:
 
   /has-unicode/2.0.1:
     resolution: {integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=, tarball: has-unicode/download/has-unicode-2.0.1.tgz}
-    dev: false
 
   /has-yarn/2.1.0:
     resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==}
@@ -8997,7 +8968,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
-    dev: false
 
   /is-callable/1.2.4:
     resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
@@ -9043,7 +9013,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       number-is-nan: 1.0.1
-    dev: false
 
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -9072,7 +9041,6 @@ packages:
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: false
 
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
@@ -9138,7 +9106,6 @@ packages:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
       '@types/estree': 0.0.52
-    dev: false
 
   /is-regex/1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -9359,7 +9326,6 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.10
-    dev: false
 
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -9651,14 +9617,12 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /magic-string/0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -10106,7 +10070,6 @@ packages:
   /mini-svg-data-uri/1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
-    dev: false
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -10322,7 +10285,6 @@ packages:
       console-control-strings: 1.1.0
       gauge: 2.7.4
       set-blocking: 2.0.0
-    dev: false
 
   /nprogress/0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
@@ -10340,7 +10302,6 @@ packages:
   /number-is-nan/1.0.1:
     resolution: {integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=, tarball: number-is-nan/download/number-is-nan-1.0.1.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -10492,7 +10453,6 @@ packages:
   /p-finally/1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
-    dev: false
 
   /p-limit/1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
@@ -10550,7 +10510,6 @@ packages:
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
-    dev: false
 
   /p-retry/4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -10564,7 +10523,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
-    dev: false
 
   /p-try/1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -11327,7 +11285,6 @@ packages:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -12014,7 +11971,6 @@ packages:
       rollup: 2.76.0
       source-map-js: 1.0.2
       tslib: 2.4.0
-    dev: false
 
   /rollup-plugin-visualizer/5.8.3_rollup@2.76.0:
     resolution: {integrity: sha512-QGJk4Bqe4AOat5AjipOh8esZH1nck5X2KFpf4VytUdSUuuuSwvIQZjMGgjcxe/zXexltqaXp5Vx1V3LmnQH15Q==}
@@ -12030,7 +11986,6 @@ packages:
       rollup: 2.76.0
       source-map: 0.7.4
       yargs: 17.5.1
-    dev: false
 
   /rollup/2.76.0:
     resolution: {integrity: sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==}
@@ -12038,7 +11993,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /rtl-detect/1.0.4:
     resolution: {integrity: sha512-EBR4I2VDSSYr7PkBmFy04uhycIpDKp+21p/jARYXlCSjQksTBQcJ0HFUPOO79EPPH5JS6VAhiIQbycf0O3JAxQ==}
@@ -12303,7 +12257,6 @@ packages:
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=, tarball: set-blocking/download/set-blocking-2.0.0.tgz}
-    dev: false
 
   /setimmediate/1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -12439,11 +12392,9 @@ packages:
   /source-map/0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-    dev: false
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    dev: false
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -12502,7 +12453,6 @@ packages:
   /split-on-first/1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
-    dev: false
 
   /split2/3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
@@ -12534,7 +12484,6 @@ packages:
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /string-width/1.0.2:
     resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=, tarball: string-width/download/string-width-1.0.2.tgz}
@@ -12543,7 +12492,6 @@ packages:
       code-point-at: 1.1.0
       is-fullwidth-code-point: 1.0.0
       strip-ansi: 3.0.1
-    dev: false
 
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -12622,7 +12570,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
-    dev: false
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -13345,7 +13292,6 @@ packages:
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-    dev: false
 
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -14028,7 +13974,6 @@ packages:
     resolution: {integrity: sha1-3x1MIGhUNp7PPJpImPGyP72dFdM=, tarball: wide-align/download/wide-align-1.1.5.tgz}
     dependencies:
       string-width: 4.2.3
-    dev: false
 
   /widest-line/3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}


### PR DESCRIPTION
## 背景
原始文件：
<img width="715" alt="image" src="https://user-images.githubusercontent.com/44047106/210809606-73907636-d26a-4223-8ed1-a276d2b068c1.png">
构建出来的 d.ts 文件内容差异
![image](https://user-images.githubusercontent.com/44047106/210809198-8469883b-2aa4-4739-8320-74626c231fae.png)
![image](https://user-images.githubusercontent.com/44047106/210809298-ff0bfb43-a1b9-43a7-80d1-8cd5be3f1238.png)

原因是，tsx 代码先经过 swc 编译，这时候类型被擦除掉了，最后再交给 dts 插件处理的时候，就没有类型了。

1.4.0 的改动是为了修复 alias 在 d.ts 中没有被转成相对路径的问题。其实这里 swc、dts、alias 插件之前是会有循环相互依赖的问题 = = 

## 解决

dts 插件里面内置一个 ts 插件 @zerollup/ts-transform-paths，这个插件在声明文件之后把 d.ts 的  alias 转成相对路径

理论上，dts 插件和 swc 插件两个不相关了，可以并行执行的