### PR TITLE
feat: specify @ice/jsx-runtime as jsx importSource

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -15,6 +15,8 @@ After you have completed a feature or fixed a bug, you need to do three things:
 - Bump released packages version
 - Write Changelog for the released packages
 
+You can follow the steps:
+
 - Run the command line script `npm run changeset`
 - Select the packages you want to include in the changeset using `↑` and `↓` to navigate to packages, and `space` to select a package. Hit enter when all desired packages are selected.
 - You will be prompted to select a bump type for each selected package. Select an appropriate bump type for the changes made. See here for information on semver versioning

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -43,14 +43,7 @@ For more detail, please see [this documentation](https://github.com/changesets/c
 Run the following commands to publish the beta version
 
 ```bash
-# Enter the prerelese mode and generate the pre.json.
-$ npm run release:beta
-# Update to the beta version.
-$ npm run changeset:version
-# Publish the beta version to the npm.
-$ npm run changeset:publish
-# Exit the prerelese mode.
-$ npm run release:exit
+$ pnpm release:beta
 ```
 
 Then, we need to commit changes to the remote repository.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "example-*",
+    "icepkg-site"
+  ]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,8 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "example-*",
-    "icepkg-site"
-  ]
+  "ignore": []
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,19 +2,26 @@
   "mode": "exit",
   "tag": "beta",
   "initialVersions": {
-    "application": "1.0.0",
-    "pkg-plugin-example": "0.0.0",
-    "pkg-react-component-example": "0.0.0",
-    "pkg-react-multi-components-example": "0.0.0",
+    "example-application": "1.0.0",
+    "example-pkg-plugin": "0.0.0",
+    "example-pkg-react-component": "0.0.0",
+    "example-pkg-react-multi-components": "0.0.0",
     "@ice/create-pkg": "1.2.0",
     "ice-npm-utils": "3.0.2",
     "@ice/pkg": "1.5.0-beta.0",
-    "@ice/pkg-plugin-docusaurus": "1.4.3-beta.1",
+    "@ice/pkg-plugin-docusaurus": "1.4.3-beta.2",
+    "@ice/pkg-plugin-jsx-plus": "0.0.0",
     "@ice/pkg-plugin-rax-component": "1.1.0",
     "icepkg-site": "0.0.0"
   },
   "changesets": [
+    "big-donkeys-sit",
+    "happy-crabs-attend",
+    "loud-meals-attack",
+    "perfect-jars-learn",
     "pretty-lions-cry",
-    "shaggy-wasps-occur"
+    "shaggy-wasps-occur",
+    "sixty-poets-fetch",
+    "strange-planes-push"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "exit",
+  "tag": "beta",
+  "initialVersions": {
+    "application": "1.0.0",
+    "pkg-plugin-example": "0.0.0",
+    "pkg-react-component-example": "0.0.0",
+    "pkg-react-multi-components-example": "0.0.0",
+    "@ice/create-pkg": "1.2.0",
+    "ice-npm-utils": "3.0.2",
+    "@ice/pkg": "1.5.0-beta.0",
+    "@ice/pkg-plugin-docusaurus": "1.4.3-beta.1",
+    "@ice/pkg-plugin-rax-component": "1.1.0",
+    "icepkg-site": "0.0.0"
+  },
+  "changesets": [
+    "pretty-lions-cry",
+    "shaggy-wasps-occur"
+  ]
+}

--- a/.changeset/pretty-lions-cry.md
+++ b/.changeset/pretty-lions-cry.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+feat: add @ice/jsx-runtime as dependency

--- a/.changeset/shaggy-wasps-occur.md
+++ b/.changeset/shaggy-wasps-occur.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': minor
+---
+
+feat: specify @ice/jsx-runtime as jsx importSource

--- a/examples/application/package.json
+++ b/examples/application/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "application",
+  "name": "example-application",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/examples/application/package.json
+++ b/examples/application/package.json
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "pkg-react-component-example": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "css-loader": "^6.6.0",

--- a/examples/application/package.json
+++ b/examples/application/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "pkg-react-component-example": "workspace:*",
+    "example-pkg-react-component": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/plugin/package.json
+++ b/examples/plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-plugin-example",
+  "name": "example-pkg-plugin",
   "private": true,
   "version": "0.0.0",
   "main": "lib/index.js",

--- a/examples/plugin/package.json
+++ b/examples/plugin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pkg-plugin-example",
+  "private": true,
   "version": "0.0.0",
   "main": "lib/index.js",
   "type": "module",
@@ -14,9 +15,5 @@
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "typescript": "^4.5.4"
-  },
-  "peerDependencies": {
-    "@ice/pkg": "^1.4.1"
-  },
-  "private": true
+  }
 }

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -35,10 +35,10 @@
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "@ice/pkg-plugin-docusaurus": "workspace:*",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "style-unit": "^3.0.4"
   },
   "peerDependencies": {

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -29,14 +29,14 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@ice/jsx-runtime": "^0.1.1-beta.1",
+    "@ice/jsx-runtime": "^0.2.0",
     "@swc/helpers": "^0.4.14",
     "babel-runtime-jsx-plus": "^0.1.5"
   },
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "@ice/pkg-plugin-docusaurus": "workspace:*",
-    "@ice/pkg-plugin-jsx-plus": "^1.0.0",
+    "@ice/pkg-plugin-jsx-plus": "workspace:*",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "react": "^17.0.0",

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-react-component-example",
+  "name": "example-pkg-react-component",
   "version": "0.0.0",
   "private": true,
   "files": [

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@ice/pkg": "workspace:*",
-    "@ice/pkg-plugin-docusaurus": "^1.4.2",
+    "@ice/pkg-plugin-docusaurus": "workspace:*",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "@types/react": "^17.0.0",

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -28,6 +28,10 @@
     "build": "ice-pkg build",
     "prepublishOnly": "npm run build"
   },
+  "dependencies": {
+    "@ice/jsx-runtime": "^0.1.1-beta.1",
+    "@swc/helpers": "^0.4.14"
+  },
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "@ice/pkg-plugin-docusaurus": "^1.4.2",
@@ -36,9 +40,6 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "style-unit": "^3.0.4"
-  },
-  "dependencies": {
-    "@swc/helpers": "^0.4.14"
   },
   "peerDependencies": {
     "react": "^17 || ^18"

--- a/examples/react-component/src/index.tsx
+++ b/examples/react-component/src/index.tsx
@@ -6,7 +6,7 @@ export default function Component() {
   console.log(process.env.NODE_ENV);
   return (
     <>
-      <h1>Hello World</h1>
+      <h1 style={{ fontSize: '100rpx' }}>Hello World</h1>
       <Button>Hello</Button>
     </>
   );

--- a/examples/react-multi-components/package.json
+++ b/examples/react-multi-components/package.json
@@ -32,6 +32,10 @@
     "build": "ice-pkg build",
     "prepublishOnly": "npm run build"
   },
+  "dependencies": {
+    "@ice/jsx-runtime": "^0.1.1-beta.1",
+    "@swc/helpers": "^0.4.14"
+  },
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "@ice/pkg-plugin-docusaurus": "^1.4.2",

--- a/examples/react-multi-components/package.json
+++ b/examples/react-multi-components/package.json
@@ -33,7 +33,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@ice/jsx-runtime": "^0.1.1-beta.1",
+    "@ice/jsx-runtime": "^0.2.0",
     "@swc/helpers": "^0.4.14"
   },
   "devDependencies": {

--- a/examples/react-multi-components/package.json
+++ b/examples/react-multi-components/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@ice/pkg": "workspace:*",
-    "@ice/pkg-plugin-docusaurus": "^1.4.2",
+    "@ice/pkg-plugin-docusaurus": "workspace:*",
     "pkg-plugin-example": "workspace:*",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/examples/react-multi-components/package.json
+++ b/examples/react-multi-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-react-multi-components-example",
+  "name": "example-pkg-react-multi-components",
   "version": "0.0.0",
   "private": true,
   "files": [

--- a/examples/react-multi-components/package.json
+++ b/examples/react-multi-components/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@ice/pkg": "workspace:*",
     "@ice/pkg-plugin-docusaurus": "workspace:*",
-    "pkg-plugin-example": "workspace:*",
+    "example-pkg-plugin": "workspace:*",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "@types/react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "changeset": "changeset",
     "version": "changeset version && pnpm install --frozen-lockfile false",
     "release": "changeset publish",
-    "release:beta": "changeset pre enter beta",
-    "release:exit": "changeset pre exit"
+    "release:beta": "changeset pre enter beta && pnpm run version && pnpm run release && changeset pre exit"
   },
   "author": "ICE Team",
   "devDependencies": {

--- a/packages/pkg/CHANGELOG.md
+++ b/packages/pkg/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.5.0-beta.1
+
+### Minor Changes
+
+- 6f8ed24: feat: specify @ice/jsx-runtime as jsx importSource
+
+### Patch Changes
+
+- 171c1dd: chore: lock @swc/core version
+- 6981cde: fix: transform code error with babel plugin
+- 390fe97: fix: can't generate dts on Windows system
+  fix: can't generate dts when save code in dev
+- 606608f: fix: dependency will not be installed
+
 ## 1.5.0-beta.0
 
 ### Minor Changes

--- a/packages/pkg/CHANGELOG.md
+++ b/packages/pkg/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.0-beta.0
+
+### Minor Changes
+
+- 6f8ed24: feat: specify @ice/jsx-runtime as jsx importSource
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.4.1",
+  "version": "1.5.0-beta.0",
   "description": "Core service of ice component",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Core service of ice component",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -93,11 +93,16 @@ const swcPlugin = (type: TaskConfig['type'], extraSwcOptions?: Config): Plugin =
       };
     },
     options(options) {
+      const { onwarn } = options;
       options.onwarn = (warning, warn) => {
         if (warning.code === 'UNRESOLVED_IMPORT' && warning.source.includes(JSX_RUNTIME_SOURCE)) {
           checkDependencyExists(JSX_RUNTIME_SOURCE, 'https://pkg.ice.work/faq');
         }
-        warn(warning);
+        if (onwarn) {
+          onwarn(warning, warn);
+        } else {
+          warn(warning);
+        }
       };
     },
   };

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -30,9 +30,8 @@ const normalizeSwcConfig = (
     jsc: {
       transform: {
         react: {
-          // In bundle task use classic runtime because of convenience for external react
-          // In transform task use automatic runtime so it isn't necessary to import react
-          runtime: type === 'transform' ? 'automatic' : 'classic',
+          runtime: 'automatic',
+          importSource: '@ice/jsx-runtime',
         },
         legacyDecorator: true,
       },

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -95,7 +95,7 @@ const swcPlugin = (type: TaskConfig['type'], extraSwcOptions?: Config): Plugin =
     options(options) {
       options.onwarn = (warning, warn) => {
         if (warning.code === 'UNRESOLVED_IMPORT' && warning.source.includes(JSX_RUNTIME_SOURCE)) {
-          checkDependencyExists(JSX_RUNTIME_SOURCE, 'https://pkg.ice.work/guide/abilities');
+          checkDependencyExists(JSX_RUNTIME_SOURCE, 'https://pkg.ice.work/faq');
         }
         warn(warning);
       };

--- a/packages/pkg/src/tasks/transform.ts
+++ b/packages/pkg/src/tasks/transform.ts
@@ -2,9 +2,9 @@ import { performance } from 'perf_hooks';
 import { isAbsolute, resolve, extname, dirname, relative } from 'path';
 import fs from 'fs-extra';
 import consola from 'consola';
-import { loadEntryFiles, loadSource, INCLUDES_UTF8_FILE_TYPE, loadPkg } from '../helpers/load.js';
+import { loadEntryFiles, loadSource, INCLUDES_UTF8_FILE_TYPE } from '../helpers/load.js';
 import { createPluginContainer } from '../helpers/pluginContainer.js';
-import { isObject, timeFrom, cwd } from '../utils.js';
+import { checkDependencyExists, isObject, timeFrom } from '../utils.js';
 import { createLogger } from '../helpers/logger.js';
 
 import type {
@@ -18,9 +18,6 @@ import type {
 } from '../types.js';
 import type { RollupOptions, SourceMapInput } from 'rollup';
 import { getTransformEntryDirs } from '../helpers/getTaskIO.js';
-
-const pkg = loadPkg(cwd);
-const isSWCHelpersDeclaredInDependency = Boolean(pkg?.dependencies?.['@swc/helpers']);
 
 export const watchTransformTasks: RunTasks = async (taskOptionsList, context, watcher) => {
   const handleChangeFunctions: HandleChange[] = [];
@@ -85,7 +82,9 @@ async function runTransform(
   context: Context,
   updatedFile?: string,
 ): Promise<OutputResult> {
-  let isTransformDistContainingSWCHelpers = false;
+  let isDistContainingSWCHelpers = false;
+  let isDistContainingJSXRuntime = false;
+
   const { rootDir, userConfig } = context;
   const { buildTask, mode } = taskRunnerContext;
   const { name: taskName } = buildTask;
@@ -128,7 +127,7 @@ async function runTransform(
 
   logger.debug('Transform start...');
 
-  // @ts-ignore FIXME: ignore
+  // @ts-expect-error FIXME: config type.
   await container.buildStart(config);
 
   for (let i = 0; i < files.length; ++i) {
@@ -194,8 +193,11 @@ async function runTransform(
       fs.writeFileSync(files[i].dest, code, 'utf-8');
     }
 
-    if (!isTransformDistContainingSWCHelpers) {
-      isTransformDistContainingSWCHelpers = code?.includes('@swc/helpers');
+    if (!isDistContainingSWCHelpers) {
+      isDistContainingSWCHelpers = code?.includes('@swc/helpers');
+    }
+    if (!isDistContainingJSXRuntime) {
+      isDistContainingJSXRuntime = code?.includes('@ice/jsx-runtime');
     }
 
     logger.debug(`Transform file ${files[i].absolutePath}`, timeFrom(traverseFileStart));
@@ -205,9 +207,11 @@ async function runTransform(
 
   logger.info(`✅ ${timeFrom(start)}`);
 
-  if (isTransformDistContainingSWCHelpers && !isSWCHelpersDeclaredInDependency) {
-    logger.warn('⚠️ The transformed dist contains @swc/helpers, please run `npm i @swc/helpers -S` command to install it as dependency. See https://pkg.ice.work/guide/abilities for more detail.');
-    process.exit(1);
+  if (isDistContainingSWCHelpers) {
+    checkDependencyExists('@swc/helpers', 'https://pkg.ice.work/guide/abilities');
+  }
+  if (isDistContainingJSXRuntime) {
+    checkDependencyExists('@ice/jsx-runtime', 'https://pkg.ice.work/guide/abilities');
   }
 
   return {

--- a/packages/pkg/src/tasks/transform.ts
+++ b/packages/pkg/src/tasks/transform.ts
@@ -208,10 +208,10 @@ async function runTransform(
   logger.info(`✅ ${timeFrom(start)}`);
 
   if (isDistContainingSWCHelpers) {
-    checkDependencyExists('@swc/helpers', 'https://pkg.ice.work/guide/abilities');
+    checkDependencyExists('@swc/helpers', 'https://pkg.ice.work/faq');
   }
   if (isDistContainingJSXRuntime) {
-    checkDependencyExists('@ice/jsx-runtime', 'https://pkg.ice.work/guide/abilities');
+    checkDependencyExists('@ice/jsx-runtime', 'https://pkg.ice.work/faq');
   }
 
   return {

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -6,16 +6,15 @@ import os from 'os';
 import debug from 'debug';
 import { createRequire } from 'module';
 import { createFilter } from '@rollup/pluginutils';
+import remapping from '@ampproject/remapping';
+import { loadPkg } from './helpers/load.js';
+import consola from 'consola';
 
 import type { PlainObject, OutputResult, TaskConfig } from './types';
-
 import type {
   DecodedSourceMap,
   RawSourceMap,
 } from '@ampproject/remapping';
-
-import remapping from '@ampproject/remapping';
-
 import type { FSWatcher } from 'chokidar';
 
 export function toArray<T>(any: T | T[]): T[] {
@@ -326,4 +325,13 @@ export function mergeValueToTaskConfig<C = TaskConfig, T = any>(config: C, key: 
 export function getEntryItems(entry: TaskConfig['entry']) {
   const entries = typeof entry === 'string' ? [entry] : Array.isArray(entry) ? entry : Object.values(entry);
   return entries;
+}
+
+const pkg = loadPkg(cwd);
+
+export function checkDependencyExists(dependency: string, link: string) {
+  if (!pkg?.dependencies?.[dependency]) {
+    consola.error(`当前组件/库依赖 \`${dependency}\`, 请运行命令 \`npm i ${dependency} --save\` 安装此依赖。更多详情请看 \`${link}\``);
+    process.exit(1);
+  }
 }

--- a/packages/plugin-docusaurus/CHANGELOG.md
+++ b/packages/plugin-docusaurus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.3-beta.3
+
+### Patch Changes
+
+- 6f9404d: feat: support configure docusaurus plugin 9f1100c2
+- 6f8ed24: feat: add @ice/jsx-runtime as dependency
+
 ## 1.4.3-beta.2
 
 ### Patch Changes

--- a/packages/plugin-docusaurus/CHANGELOG.md
+++ b/packages/plugin-docusaurus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3-beta.2
+
+### Patch Changes
+
+- 6f8ed24: feat: add @ice/jsx-runtime as dependency
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -38,6 +38,7 @@
     "@docusaurus/preset-classic": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "@swc/helpers": "^0.4.3",
+    "@ice/jsx-runtime": "^0.1.1-beta.1",
     "address": "^1.2.1",
     "consola": "^2.15.3",
     "copy-text-to-clipboard": "^3.0.1",

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg-plugin-docusaurus",
-  "version": "1.4.2",
+  "version": "1.4.3-beta.2",
   "description": "Plugin for component previewing",
   "main": "es2017/index.mjs",
   "exports": {
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@algolia/client-search": "^4.9.1",
     "@types/react": "^17.0.0",
-    "@ice/pkg": "^1.4.1",
+    "@ice/pkg": "^1.5.0-beta.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "typescript": "^4.9.3",

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg-plugin-docusaurus",
-  "version": "1.4.3-beta.2",
+  "version": "1.4.3-beta.3",
   "description": "Plugin for component previewing",
   "main": "es2017/index.mjs",
   "exports": {
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@algolia/client-search": "^4.9.1",
     "@types/react": "^17.0.0",
-    "@ice/pkg": "^1.5.0-beta.0",
+    "@ice/pkg": "^1.5.0-beta.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "typescript": "^4.9.3",

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -39,7 +39,7 @@
     "@docusaurus/plugin-content-pages": "^2.3.0",
     "@mdx-js/react": "^1.6.22",
     "@swc/helpers": "^0.4.3",
-    "@ice/jsx-runtime": "^0.1.1-beta.1",
+    "@ice/jsx-runtime": "^0.2.0",
     "address": "^1.2.1",
     "consola": "^2.15.3",
     "copy-text-to-clipboard": "^3.0.1",

--- a/packages/plugin-jsx-plus/CHANGELOG.md
+++ b/packages/plugin-jsx-plus/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog
+
+## 1.0.0-beta.0
+
+### Major Changes
+
+- 11a2dd9: feat: init plugin

--- a/packages/plugin-jsx-plus/package.json
+++ b/packages/plugin-jsx-plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg-plugin-jsx-plus",
-  "version": "0.0.0",
+  "version": "1.0.0-beta.0",
   "description": "ICE PKG plugin for jsx-plus",
   "main": "es2017/index.js",
   "type": "module",
@@ -29,7 +29,7 @@
     "babel-plugin-transform-jsx-slot": "^0.1.2"
   },
   "devDependencies": {
-    "@ice/pkg": "^1.4.1"
+    "@ice/pkg": "^1.5.0-beta.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rax-component/package.json
+++ b/packages/plugin-rax-component/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@ice/pkg": "^1.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "typescript": "^4.9.4"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,7 @@ importers:
       '@algolia/client-search': ^4.9.1
       '@docusaurus/core': ^2.2.0
       '@docusaurus/preset-classic': ^2.2.0
+      '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg': ^1.4.1
       '@mdx-js/react': ^1.6.22
       '@swc/helpers': ^0.4.3
@@ -273,6 +274,7 @@ importers:
     dependencies:
       '@docusaurus/core': 2.2.0_wfh3mw2ke2bdr53qfq544ltemu
       '@docusaurus/preset-classic': 2.2.0_zj3epevdq6d4ikykdk7jwyp4wa
+      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@swc/helpers': 0.4.3
       address: 1.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,10 +68,10 @@ importers:
 
   examples/react-component:
     specifiers:
-      '@ice/jsx-runtime': ^0.1.1-beta.1
+      '@ice/jsx-runtime': ^0.2.0
       '@ice/pkg': workspace:*
-      '@ice/pkg-plugin-docusaurus': ^1.4.2
-      '@ice/pkg-plugin-jsx-plus': ^1.0.0
+      '@ice/pkg-plugin-docusaurus': workspace:*
+      '@ice/pkg-plugin-jsx-plus': workspace:*
       '@swc/helpers': ^0.4.14
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -80,7 +80,7 @@ importers:
       react-dom: ^17.0.0
       style-unit: ^3.0.4
     dependencies:
-      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
+      '@ice/jsx-runtime': 0.2.0_react@17.0.2
       '@swc/helpers': 0.4.14
       babel-runtime-jsx-plus: 0.1.5
     devDependencies:
@@ -95,7 +95,7 @@ importers:
 
   examples/react-multi-components:
     specifiers:
-      '@ice/jsx-runtime': ^0.1.1-beta.1
+      '@ice/jsx-runtime': ^0.2.0
       '@ice/pkg': workspace:*
       '@ice/pkg-plugin-docusaurus': workspace:*
       '@swc/helpers': ^0.4.14
@@ -106,7 +106,7 @@ importers:
       react-dom: ^17.0.0
       style-unit: ^3.0.4
     dependencies:
-      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
+      '@ice/jsx-runtime': 0.2.0_react@17.0.2
       '@swc/helpers': 0.4.14
     devDependencies:
       '@ice/pkg': link:../../packages/pkg
@@ -247,7 +247,8 @@ importers:
       '@docusaurus/core': ^2.3.0
       '@docusaurus/plugin-content-pages': ^2.3.0
       '@docusaurus/preset-classic': ^2.3.0
-      '@ice/pkg': ^1.4.1
+      '@ice/jsx-runtime': ^0.2.0
+      '@ice/pkg': ^1.5.0-beta.0
       '@mdx-js/react': ^1.6.22
       '@swc/helpers': ^0.4.3
       '@types/react': ^17.0.0
@@ -283,6 +284,7 @@ importers:
       '@docusaurus/core': 2.3.0_wfh3mw2ke2bdr53qfq544ltemu
       '@docusaurus/plugin-content-pages': 2.3.0_wfh3mw2ke2bdr53qfq544ltemu
       '@docusaurus/preset-classic': 2.3.0_zj3epevdq6d4ikykdk7jwyp4wa
+      '@ice/jsx-runtime': 0.2.0_react@17.0.2
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@swc/helpers': 0.4.3
       address: 1.2.1
@@ -335,7 +337,7 @@ importers:
       babel-plugin-transform-jsx-memo: 0.1.4
       babel-plugin-transform-jsx-slot: 0.1.2
     devDependencies:
-      '@ice/pkg': link:../pkg
+      '@ice/pkg': 1.4.1
 
   packages/plugin-rax-component:
     specifiers:
@@ -382,7 +384,7 @@ importers:
       '@algolia/client-search': 4.13.1
       '@docusaurus/module-type-aliases': 2.3.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/theme-common': 2.3.0_3tgeifm2vmwrlpqlopppsnjtcu
-      '@ice/pkg-plugin-docusaurus': link:../packages/plugin-docusaurus
+      '@ice/pkg-plugin-docusaurus': 1.4.2_tamhlxc7qrywbuihnmn3loh2be
       '@tsconfig/docusaurus': 1.0.6
       '@types/react': 17.0.52
       typescript: 4.7.4
@@ -2300,7 +2302,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/core/2.3.0_lfww5efxwgoqmcte7kpjyja7bi:
     resolution: {integrity: sha512-2AU5HfKyExO+/mi41SBnx5uY0aGZFXr3D93wntBY4lN1gsDKUpi7EE4lPBAXm9CoH4Pw6N24yDHy9CPR3sh/uA==}
@@ -3116,7 +3117,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/plugin-google-analytics/2.3.0_3tgeifm2vmwrlpqlopppsnjtcu:
     resolution: {integrity: sha512-Z9FqTQzeOC1R6i/x07VgkrTKpQ4OtMe3WBOKZKzgldWXJr6CDUWPSR8pfDEjA+RRAj8ajUh0E+BliKBmFILQvQ==}
@@ -3145,7 +3145,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/plugin-google-analytics/2.3.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-Z9FqTQzeOC1R6i/x07VgkrTKpQ4OtMe3WBOKZKzgldWXJr6CDUWPSR8pfDEjA+RRAj8ajUh0E+BliKBmFILQvQ==}
@@ -3203,7 +3202,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/plugin-google-gtag/2.3.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-oZavqtfwQAGjz+Dyhsb45mVssTevCW1PJgLcmr3WKiID15GTolbBrrp/fueTrEh60DzOd81HbiCLs56JWBwDhQ==}
@@ -3261,7 +3259,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/plugin-google-tag-manager/2.3.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-toAhuMX1h+P2CfavwoDlz9s2/Zm7caiEznW/inxq3izywG2l9ujWI/o6u2g70O3ACQ19eHMGHDsyEUcRDPrxBw==}
@@ -3324,7 +3321,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/plugin-sitemap/2.3.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-kwIHLP6lyubWOnNO0ejwjqdxB9C6ySnATN61etd6iwxHri5+PBZCEOv1sVm5U1gfQiDR1sVsXnJq2zNwLwgEtQ==}
@@ -3399,7 +3395,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/preset-classic/2.3.0_zj3epevdq6d4ikykdk7jwyp4wa:
     resolution: {integrity: sha512-mI37ieJe7cs5dHuvWz415U7hO209Q19Fp4iSHeFFgtQoK1PiRg7HJHkVbEsLZII2MivdzGFB5Hxoq2wUPWdNEA==}
@@ -3499,7 +3494,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/theme-classic/2.3.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-x2h9KZ4feo22b1aArsfqvK05aDCgTkLZGRgAPY/9TevFV5/Yy19cZtBOCbzaKa2dKq1ofBRK9Hm1DdLJdLB14A==}
@@ -3671,7 +3665,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/theme-search-algolia/2.3.0_4ph6vqy3g2yu3qbwe7syyderlq:
     resolution: {integrity: sha512-/i5k1NAlbYvgnw69vJQA174+ipwdtTCCUvxRp7bVZ+8KmviEybAC/kuKe7WmiUbIGVYbAbwYaEsPuVnsd65DrA==}
@@ -3715,7 +3708,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/theme-search-algolia/2.3.0_ulcwq6qru5twdzgeh5fpmyljqa:
     resolution: {integrity: sha512-/i5k1NAlbYvgnw69vJQA174+ipwdtTCCUvxRp7bVZ+8KmviEybAC/kuKe7WmiUbIGVYbAbwYaEsPuVnsd65DrA==}
@@ -3760,50 +3752,6 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
-
-  /@docusaurus/theme-search-algolia/2.2.0_qjmc7u5hculwzstel6kzrdwhia:
-    resolution: {integrity: sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==}
-    engines: {node: '>=16.14'}
-    peerDependencies:
-      react: ^16.8.4 || ^17.0.0
-      react-dom: ^16.8.4 || ^17.0.0
-    dependencies:
-      '@docsearch/react': 3.1.1_c6kcmqf4p25qrgl2rpjskujhsi
-      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/plugin-content-docs': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
-      '@docusaurus/theme-common': 2.2.0_e4pyalr7znoa3t23syhqu25gga
-      '@docusaurus/theme-translations': 2.2.0
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
-      algoliasearch: 4.13.1
-      algoliasearch-helper: 3.10.0_algoliasearch@4.13.1
-      clsx: 1.2.1
-      eta: 1.12.3
-      fs-extra: 10.1.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      tslib: 2.4.0
-      utility-types: 3.10.0
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - '@docusaurus/types'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@types/react'
-      - bufferutil
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-    dev: true
 
   /@docusaurus/theme-translations/2.0.1:
     resolution: {integrity: sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==}
@@ -4260,8 +4208,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@ice/jsx-runtime/0.1.1-beta.1_react@17.0.2:
-    resolution: {integrity: sha512-AIa7/M5Q0dYU+5Gp3Jsgp3uwFpH7cvMz8P5KxJBIkTZz1t6mDMWK3ASaSZyP6HhreehpCGEpALZ0vSx0CMUj4w==}
+  /@ice/jsx-runtime/0.2.0_react@17.0.2:
+    resolution: {integrity: sha512-yUfoWloQq2mdyCTsTTWwxtx0dmiwC4Xe2QEaQCg/yFqQKz7hOFBOrju6RodMl7K0fdpj6k1UBfjLd9gPyUBAbw==}
     peerDependencies:
       react: ^16 || ^17 || ^18
     dependencies:
@@ -4272,8 +4220,8 @@ packages:
   /@ice/pkg-plugin-docusaurus/1.4.2_tamhlxc7qrywbuihnmn3loh2be:
     resolution: {integrity: sha512-hxMB82ewnzk5Zj/1/o12bKl7TCGGUuoBirYrwadWQeNm5wVKHy4GyZipgw8qvWkY4Z0ar+eFF+F5sQFEmmUQog==}
     dependencies:
-      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
-      '@docusaurus/preset-classic': 2.2.0_tamhlxc7qrywbuihnmn3loh2be
+      '@docusaurus/core': 2.3.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/preset-classic': 2.3.0_tamhlxc7qrywbuihnmn3loh2be
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@swc/helpers': 0.4.14
       address: 1.2.1
@@ -4281,8 +4229,8 @@ packages:
       copy-text-to-clipboard: 3.0.1
       detect-port: 1.3.0
       directory-tree: 3.3.1
-      docusaurus-plugin-less: 2.0.2_h7k4fbmhvh7tyycryrahgmkyge
-      docusaurus-plugin-sass: 0.2.2_6wqf4cuv72z6apsq26qakw4k4e
+      docusaurus-plugin-less: 2.0.2_ufmo642ts42rvy7eqlquam4g74
+      docusaurus-plugin-sass: 0.2.2_wqqmeqipvoyuqg6bhtexqkgus4
       es-module-lexer: 0.10.5
       fs-extra: 10.1.0
       handlebars: 4.7.7
@@ -5017,6 +4965,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -5025,6 +4974,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -5033,6 +4983,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -5041,6 +4992,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -7293,13 +7245,13 @@ packages:
       less: 4.1.3
       less-loader: 11.0.0_less@4.1.3+webpack@5.75.0
 
-  /docusaurus-plugin-sass/0.2.2_6wqf4cuv72z6apsq26qakw4k4e:
+  /docusaurus-plugin-sass/0.2.2_wqqmeqipvoyuqg6bhtexqkgus4:
     resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
     peerDependencies:
       '@docusaurus/core': ^2.0.0-beta
       sass: ^1.30.0
     dependencies:
-      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/core': 2.3.0_3tgeifm2vmwrlpqlopppsnjtcu
       sass: 1.53.0
       sass-loader: 10.3.1_sass@1.53.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,15 +43,15 @@ importers:
     specifiers:
       css-loader: ^6.6.0
       pkg-react-component-example: workspace:*
-      react: ^18.2.0
-      react-dom: ^18.2.0
+      react: ^17.0.2
+      react-dom: ^17.0.2
       style-loader: ^3.3.1
       webpack: ^5.69.1
       webpack-cli: ^4.9.2
     dependencies:
       pkg-react-component-example: link:../react-component
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     devDependencies:
       css-loader: 6.7.1_webpack@5.73.0
       style-loader: 3.3.1_webpack@5.73.0
@@ -314,15 +314,15 @@ importers:
     specifiers:
       '@ice/pkg': ^1.0.0
       rax-compat: ^0.1.5
-      react: ^18.2.0
-      react-dom: ^18.2.0
+      react: ^17.0.2
+      react-dom: ^17.0.2
       typescript: ^4.9.4
     dependencies:
-      rax-compat: 0.1.5_biqbaboplfbrettd7655fr4n2y
+      rax-compat: 0.1.5_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@ice/pkg': 1.4.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       typescript: 4.9.4
 
   website:
@@ -333,7 +333,6 @@ importers:
       '@docusaurus/preset-classic': ^2.0.1
       '@docusaurus/theme-common': ^2.2.0
       '@easyops-cn/docusaurus-search-local': ^0.33.6
-      '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg-plugin-docusaurus': ^1.4.2
       '@mdx-js/react': ^1.6.22
       '@tsconfig/docusaurus': ^1.0.5
@@ -356,7 +355,6 @@ importers:
       '@algolia/client-search': 4.13.1
       '@docusaurus/module-type-aliases': 2.0.1_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/theme-common': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
-      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
       '@ice/pkg-plugin-docusaurus': 1.4.2_tamhlxc7qrywbuihnmn3loh2be
       '@tsconfig/docusaurus': 1.0.6
       '@types/react': 17.0.52
@@ -1688,6 +1686,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+    dev: true
 
   /@babel/template/7.18.6:
     resolution: {integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==}
@@ -2059,7 +2058,6 @@ packages:
   /@discoveryjs/json-ext/0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /@docsearch/css/3.1.1:
     resolution: {integrity: sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg==}
@@ -2373,6 +2371,7 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
+    dev: true
 
   /@docusaurus/core/2.2.0_aeigrxhfhc4abyd45ix2hknizy:
     resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
@@ -2763,7 +2762,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/cssnano-preset/2.0.1:
     resolution: {integrity: sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==}
@@ -4719,14 +4717,14 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@ice/appear/0.1.3_biqbaboplfbrettd7655fr4n2y:
+  /@ice/appear/0.1.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-pG07U1C4a3FZkebfRsBQNezgIG2SFERFq2vFWyshkCJXI2pAsUgAVtwkRPE7s3ECeycewVWEn91XX6r0VzwcQA==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: false
 
   /@ice/jsx-runtime/0.1.1-beta.1_react@17.0.2:
@@ -4736,6 +4734,7 @@ packages:
     dependencies:
       react: 17.0.2
       style-unit: 3.0.5
+    dev: false
 
   /@ice/pkg-plugin-docusaurus/1.4.2_tamhlxc7qrywbuihnmn3loh2be:
     resolution: {integrity: sha512-hxMB82ewnzk5Zj/1/o12bKl7TCGGUuoBirYrwadWQeNm5wVKHy4GyZipgw8qvWkY4Z0ar+eFF+F5sQFEmmUQog==}
@@ -6141,7 +6140,6 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.73.0
-    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -6150,7 +6148,6 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0_webpack@5.73.0
-    dev: true
 
   /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -6162,7 +6159,6 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0_webpack@5.73.0
-    dev: true
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -7758,9 +7754,9 @@ packages:
       less: '>=4.0.0'
       less-loader: '>=10.0.0'
     dependencies:
-      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/core': 2.2.0_wfh3mw2ke2bdr53qfq544ltemu
       less: 4.1.3
-      less-loader: 11.0.0_less@4.1.3
+      less-loader: 11.0.0_less@4.1.3+webpack@5.75.0
 
   /docusaurus-plugin-sass/0.2.2_6wqf4cuv72z6apsq26qakw4k4e:
     resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
@@ -7954,7 +7950,6 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /errno/0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
@@ -8639,7 +8634,6 @@ packages:
 
   /fastest-levenshtein/1.0.12:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
-    dev: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -8898,7 +8892,6 @@ packages:
       tapable: 1.1.3
       typescript: 4.9.3
       webpack: 5.75.0
-    dev: false
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -9623,7 +9616,6 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
-    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -9696,7 +9688,6 @@ packages:
   /interpret/2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
-    dev: true
 
   /invariant/2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -10214,6 +10205,7 @@ packages:
     dependencies:
       klona: 2.0.5
       less: 4.1.3
+    dev: true
 
   /less-loader/11.0.0_less@4.1.3+webpack@5.75.0:
     resolution: {integrity: sha512-9+LOWWjuoectIEx3zrfN83NAGxSUB5pWEabbbidVQVgZhN+wN68pOvuyirVlH1IK4VT1f3TmlyvAnCXh8O5KEw==}
@@ -10225,7 +10217,6 @@ packages:
       klona: 2.0.5
       less: 4.1.3
       webpack: 5.75.0
-    dev: false
 
   /less/4.1.3:
     resolution: {integrity: sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==}
@@ -12183,17 +12174,17 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  /rax-compat/0.1.5_biqbaboplfbrettd7655fr4n2y:
+  /rax-compat/0.1.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-qjFc8/XvTkr2NMnHzG98ZctbYzyF46iMIudhbVNF8rjKYYy3W7fyqapRqELOGVFqUOt0I0CSPu288cTgCaq/aQ==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      '@ice/appear': 0.1.3_biqbaboplfbrettd7655fr4n2y
+      '@ice/appear': 0.1.3_sfoxds7t5ydpegc3knd667wn6m
       '@swc/helpers': 0.4.14
       create-react-class: 15.7.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       style-unit: 3.0.5
     dev: false
 
@@ -12295,7 +12286,6 @@ packages:
       - eslint
       - supports-color
       - vue-template-compiler
-    dev: false
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -12306,15 +12296,6 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-
-  /react-dom/18.2.0_react@18.2.0:
-    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
-    peerDependencies:
-      react: ^18.2.0
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.0
 
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
@@ -12442,12 +12423,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
-  /react/18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
@@ -12525,7 +12500,6 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.1
-    dev: true
 
   /recursive-readdir/2.2.2:
     resolution: {integrity: sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==}
@@ -12556,6 +12530,7 @@ packages:
 
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: true
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
@@ -12755,7 +12730,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
-    dev: true
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -12764,7 +12738,6 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-global/1.0.0:
     resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
@@ -13025,11 +12998,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-
-  /scheduler/0.23.0:
-    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
-    dependencies:
-      loose-envify: 1.4.0
 
   /schema-utils/2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -13582,7 +13550,7 @@ packages:
   /style-unit/3.0.5:
     resolution: {integrity: sha512-xL+kev1W1dPthdhpQqZs9Qk1zenQiHKyy9oy2/VasW4z6wi7m7qQvMe67foPsr99JSs0115X0TCN1ch1n0XqSw==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.18.6
       universal-env: 3.3.3
 
   /stylehacks/5.1.0_postcss@8.4.14:
@@ -13792,7 +13760,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.1
-      webpack: 5.73.0
+      webpack: 5.73.0_webpack-cli@4.10.0
 
   /terser-webpack-plugin/5.3.3_webpack@5.75.0:
     resolution: {integrity: sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==}
@@ -14634,7 +14602,6 @@ packages:
       rechoir: 0.7.1
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
-    dev: true
 
   /webpack-dev-middleware/5.3.3_webpack@5.75.0:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -14833,7 +14800,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack/5.75.0:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1698,7 +1698,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@babel/template/7.18.6:
     resolution: {integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==}
@@ -12172,7 +12171,6 @@ packages:
 
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
@@ -13155,7 +13153,7 @@ packages:
   /style-unit/3.0.5:
     resolution: {integrity: sha512-xL+kev1W1dPthdhpQqZs9Qk1zenQiHKyy9oy2/VasW4z6wi7m7qQvMe67foPsr99JSs0115X0TCN1ch1n0XqSw==}
     dependencies:
-      '@babel/runtime': 7.18.6
+      '@babel/runtime': 7.20.7
       universal-env: 3.3.3
 
   /stylehacks/5.1.0_postcss@8.4.14:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
     specifiers:
       '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg': workspace:*
-      '@ice/pkg-plugin-docusaurus': ^1.4.2
+      '@ice/pkg-plugin-docusaurus': workspace:*
       '@swc/helpers': ^0.4.14
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -93,7 +93,7 @@ importers:
     specifiers:
       '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg': workspace:*
-      '@ice/pkg-plugin-docusaurus': ^1.4.2
+      '@ice/pkg-plugin-docusaurus': workspace:*
       '@swc/helpers': ^0.4.14
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,7 +239,7 @@ importers:
       '@docusaurus/core': ^2.2.0
       '@docusaurus/preset-classic': ^2.2.0
       '@ice/jsx-runtime': ^0.1.1-beta.1
-      '@ice/pkg': ^1.4.1
+      '@ice/pkg': ^1.5.0-beta.0
       '@mdx-js/react': ^1.6.22
       '@swc/helpers': ^0.4.3
       '@types/react': ^17.0.0
@@ -320,7 +320,7 @@ importers:
     dependencies:
       rax-compat: 0.1.5_biqbaboplfbrettd7655fr4n2y
     devDependencies:
-      '@ice/pkg': link:../pkg
+      '@ice/pkg': 1.4.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.9.4
@@ -333,7 +333,7 @@ importers:
       '@docusaurus/preset-classic': ^2.0.1
       '@docusaurus/theme-common': ^2.2.0
       '@easyops-cn/docusaurus-search-local': ^0.33.6
-      '@ice/pkg-plugin-docusaurus': ^1.2.0
+      '@ice/pkg-plugin-docusaurus': workspace:*
       '@mdx-js/react': ^1.6.22
       '@tsconfig/docusaurus': ^1.0.5
       '@types/react': ^17.0.0
@@ -4357,6 +4357,44 @@ packages:
       style-unit: 3.0.5
     dev: false
 
+  /@ice/pkg/1.4.1:
+    resolution: {integrity: sha512-j0Ib6ecDPWMEvt3QtNLQnwVyXtOQYPUmbvG6UG1CfjwQ3WOwe/QVa/dxNKbwUxkcZqZrlQ5IuQsP3gvN2Hjjwg==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/parser': 7.18.8
+      '@rollup/plugin-commonjs': 21.1.0_rollup@2.76.0
+      '@rollup/plugin-image': 3.0.1_rollup@2.76.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.76.0
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.76.0
+      '@rollup/plugin-replace': 5.0.1_rollup@2.76.0
+      '@rollup/pluginutils': 4.2.1
+      '@swc/core': 1.2.211
+      acorn: 8.7.1
+      autoprefixer: 10.4.7_postcss@8.4.14
+      build-scripts: 2.0.0
+      cac: 6.7.12
+      chokidar: 3.5.3
+      consola: 2.15.3
+      debug: 4.3.4
+      deepmerge: 4.2.2
+      escape-string-regexp: 5.0.0
+      fs-extra: 10.1.0
+      globby: 11.1.0
+      gzip-size: 7.0.0
+      magic-string: 0.25.9
+      picocolors: 1.0.0
+      postcss: 8.4.14
+      rollup: 2.76.0
+      rollup-plugin-styles: 4.0.0_rollup@2.76.0
+      rollup-plugin-visualizer: 5.8.3_rollup@2.76.0
+      tsc-alias: 1.8.2
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@iceworks/eslint-plugin-best-practices/0.2.11_boy655tvqsm6op45de6ax7jimi:
     resolution: {integrity: sha512-IsMqWijTyj1c8EBP8oZJhhghz01XUm8hh2AreUvQyi/eCgAcr0MgPXZ94NkXB+1OwCskkiVuXTa+fsooeP0IYA==}
     dependencies:
@@ -4713,7 +4751,6 @@ packages:
       magic-string: 0.25.9
       resolve: 1.22.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-image/3.0.1_rollup@2.76.0:
     resolution: {integrity: sha512-F50Sko4Xcc576x7HG9f3MvJKKnBfSmqfVFWJkJgyIEkI8YxZxux28lDbuy0+GsAK6BFl9Gn+TRXOUgHHJbFh3w==}
@@ -4727,7 +4764,6 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@2.76.0
       mini-svg-data-uri: 1.4.4
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-json/4.1.0_rollup@2.76.0:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
@@ -4736,7 +4772,6 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.76.0
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.76.0:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
@@ -4751,7 +4786,6 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/plugin-replace/5.0.1_rollup@2.76.0:
     resolution: {integrity: sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==}
@@ -4765,7 +4799,6 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@2.76.0
       magic-string: 0.26.7
       rollup: 2.76.0
-    dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@2.76.0:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
@@ -4777,7 +4810,6 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.1
       rollup: 2.76.0
-    dev: false
 
   /@rollup/pluginutils/4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -4785,7 +4817,6 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: false
 
   /@rollup/pluginutils/5.0.2_rollup@2.76.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -4800,7 +4831,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 2.76.0
-    dev: false
 
   /@sideway/address/4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -4996,7 +5026,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-android-arm64/1.2.211:
@@ -5005,7 +5034,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-arm64/1.2.211:
@@ -5014,7 +5042,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-x64/1.2.211:
@@ -5023,7 +5050,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-freebsd-x64/1.2.211:
@@ -5032,7 +5058,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.2.211:
@@ -5041,7 +5066,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.2.211:
@@ -5051,7 +5075,6 @@ packages:
     os: [linux]
     libc: [glibc]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl/1.2.211:
@@ -5061,7 +5084,6 @@ packages:
     os: [linux]
     libc: [musl]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu/1.2.211:
@@ -5071,7 +5093,6 @@ packages:
     os: [linux]
     libc: [glibc]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-musl/1.2.211:
@@ -5081,7 +5102,6 @@ packages:
     os: [linux]
     libc: [musl]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.2.211:
@@ -5090,7 +5110,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.2.211:
@@ -5099,7 +5118,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-x64-msvc/1.2.211:
@@ -5108,7 +5126,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core/1.2.211:
@@ -5129,7 +5146,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.211
       '@swc/core-win32-ia32-msvc': 1.2.211
       '@swc/core-win32-x64-msvc': 1.2.211
-    dev: false
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -5241,7 +5257,6 @@ packages:
       cssnano: 5.1.12_postcss@8.4.14
     transitivePeerDependencies:
       - postcss
-    dev: false
 
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -5263,18 +5278,15 @@ packages:
 
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
-    dev: false
 
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
   /@types/estree/0.0.52:
     resolution: {integrity: sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==}
-    dev: false
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: false
 
   /@types/express-serve-static-core/4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
@@ -5423,7 +5435,6 @@ packages:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
       '@types/node': 17.0.45
-    dev: false
 
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -5880,7 +5891,6 @@ packages:
   /ansi-regex/2.1.1:
     resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=, tarball: ansi-regex/download/ansi-regex-2.1.1.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5915,14 +5925,12 @@ packages:
 
   /aproba/1.2.0:
     resolution: {integrity: sha1-aALmJk79GMeQobDVF/DyYnvyyUo=, tarball: aproba/download/aproba-1.2.0.tgz}
-    dev: false
 
   /are-we-there-yet/1.1.7:
     resolution: {integrity: sha1-sVR0qTKtq0/4pQ2a36fk6SbyEUY=, tarball: are-we-there-yet/download/are-we-there-yet-1.1.7.tgz}
     dependencies:
       delegates: 1.0.0
       readable-stream: 2.3.7
-    dev: false
 
   /arg/4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -6299,12 +6307,10 @@ packages:
       npmlog: 4.1.2
       picocolors: 1.0.0
       semver: 7.3.7
-    dev: false
 
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-    dev: false
 
   /builtins/1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
@@ -6340,7 +6346,6 @@ packages:
   /cac/6.7.12:
     resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
     engines: {node: '>=8'}
-    dev: false
 
   /cacheable-request/6.1.0:
     resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==}
@@ -6603,7 +6608,6 @@ packages:
   /code-point-at/1.1.0:
     resolution: {integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=, tarball: code-point-at/download/code-point-at-1.1.0.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /collapse-white-space/1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
@@ -6676,7 +6680,6 @@ packages:
   /commander/9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
-    dev: false
 
   /commitlint-config-ali/0.1.3:
     resolution: {integrity: sha512-udq2cb0i9uXfT6JOgOL7w+iJ0NCcg84az3i6vqEHNI1GCeKXOdZCAjz20XE5dvyWVIfFMcj3d3J0ydgCL6eJHQ==}
@@ -6737,7 +6740,6 @@ packages:
 
   /console-control-strings/1.1.0:
     resolution: {integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=, tarball: console-control-strings/download/console-control-strings-1.1.0.tgz}
-    dev: false
 
   /content-disposition/0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -7168,7 +7170,6 @@ packages:
   /decode-uri-component/0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
-    dev: false
 
   /decompress-response/3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
@@ -7235,7 +7236,6 @@ packages:
 
   /delegates/1.0.0:
     resolution: {integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=, tarball: delegates/download/delegates-1.0.0.tgz}
-    dev: false
 
   /depd/1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -7595,7 +7595,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-android-arm64/0.14.49:
@@ -7604,7 +7603,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-64/0.14.49:
@@ -7613,7 +7611,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.14.49:
@@ -7622,7 +7619,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-64/0.14.49:
@@ -7631,7 +7627,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.14.49:
@@ -7640,7 +7635,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-32/0.14.49:
@@ -7649,7 +7643,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-64/0.14.49:
@@ -7658,7 +7651,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm/0.14.49:
@@ -7667,7 +7659,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.14.49:
@@ -7676,7 +7667,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-mips64le/0.14.49:
@@ -7685,7 +7675,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.14.49:
@@ -7694,7 +7683,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-riscv64/0.14.49:
@@ -7703,7 +7691,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-s390x/0.14.49:
@@ -7712,7 +7699,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-netbsd-64/0.14.49:
@@ -7721,7 +7707,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.14.49:
@@ -7730,7 +7715,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-sunos-64/0.14.49:
@@ -7739,7 +7723,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-32/0.14.49:
@@ -7748,7 +7731,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-64/0.14.49:
@@ -7757,7 +7739,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.14.49:
@@ -7766,7 +7747,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild/0.14.49:
@@ -7795,7 +7775,6 @@ packages:
       esbuild-windows-32: 0.14.49
       esbuild-windows-64: 0.14.49
       esbuild-windows-arm64: 0.14.49
-    dev: false
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -7819,7 +7798,6 @@ packages:
   /escape-string-regexp/5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-    dev: false
 
   /eslint-config-ali/13.1.0_eslint@8.19.0:
     resolution: {integrity: sha512-ZjWrpiKADEmNhtfB64iVN3ejlDS5sS9OZx9+jN3mF+oqaroWqrTPvqQvY472M4ykL0JgT+AqsZdG+kWDqUw/6g==}
@@ -8094,11 +8072,9 @@ packages:
 
   /estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
-    dev: false
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: false
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -8320,7 +8296,6 @@ packages:
   /filter-obj/1.1.0:
     resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /finalhandler/1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -8596,7 +8571,6 @@ packages:
       string-width: 1.0.2
       strip-ansi: 3.0.1
       wide-align: 1.1.5
-    dev: false
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8805,7 +8779,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       duplexer: 0.1.2
-    dev: false
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -8858,7 +8831,6 @@ packages:
 
   /has-unicode/2.0.1:
     resolution: {integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=, tarball: has-unicode/download/has-unicode-2.0.1.tgz}
-    dev: false
 
   /has-yarn/2.1.0:
     resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==}
@@ -9363,7 +9335,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
-    dev: false
 
   /is-callable/1.2.4:
     resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
@@ -9416,7 +9387,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       number-is-nan: 1.0.1
-    dev: false
 
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -9445,7 +9415,6 @@ packages:
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: false
 
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
@@ -9511,7 +9480,6 @@ packages:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
       '@types/estree': 0.0.52
-    dev: false
 
   /is-regex/1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -10055,14 +10023,12 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /magic-string/0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -10527,7 +10493,6 @@ packages:
   /mini-svg-data-uri/1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
-    dev: false
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -10619,7 +10584,6 @@ packages:
   /mylas/2.1.13:
     resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
     engines: {node: '>=12.0.0'}
-    dev: false
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
@@ -10753,7 +10717,6 @@ packages:
       console-control-strings: 1.1.0
       gauge: 2.7.4
       set-blocking: 2.0.0
-    dev: false
 
   /nprogress/0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
@@ -10771,7 +10734,6 @@ packages:
   /number-is-nan/1.0.1:
     resolution: {integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=, tarball: number-is-nan/download/number-is-nan-1.0.1.tgz}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -10933,7 +10895,6 @@ packages:
   /p-finally/1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
-    dev: false
 
   /p-limit/1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
@@ -10996,7 +10957,6 @@ packages:
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
-    dev: false
 
   /p-retry/4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -11010,7 +10970,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
-    dev: false
 
   /p-try/1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -11199,7 +11158,6 @@ packages:
     resolution: {integrity: sha512-Eb/MqCb1Iv/ok4m1FqIXqvUKPISufcjZ605hl3KM/n8GaX8zfhtgdLwZU3vKjuHGh2O9Rjog/bHTq8ofIShdng==}
     dependencies:
       queue-lit: 1.5.0
-    dev: false
 
   /postcss-calc/8.2.4_postcss@8.4.14:
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
@@ -11797,11 +11755,9 @@ packages:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-    dev: false
 
   /queue-lit/1.5.0:
     resolution: {integrity: sha512-IslToJ4eiCEE9xwMzq3viOO5nH8sUWUCwoElrhNMozzr9IIt2qqvB4I+uHu/zJTQVqc9R5DFwok4ijNK1pU3fA==}
-    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -12506,7 +12462,6 @@ packages:
       rollup: 2.76.0
       source-map-js: 1.0.2
       tslib: 2.4.0
-    dev: false
 
   /rollup-plugin-visualizer/5.8.3_rollup@2.76.0:
     resolution: {integrity: sha512-QGJk4Bqe4AOat5AjipOh8esZH1nck5X2KFpf4VytUdSUuuuSwvIQZjMGgjcxe/zXexltqaXp5Vx1V3LmnQH15Q==}
@@ -12522,7 +12477,6 @@ packages:
       rollup: 2.76.0
       source-map: 0.7.4
       yargs: 17.5.1
-    dev: false
 
   /rollup/2.76.0:
     resolution: {integrity: sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==}
@@ -12530,7 +12484,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /rtl-detect/1.0.4:
     resolution: {integrity: sha512-EBR4I2VDSSYr7PkBmFy04uhycIpDKp+21p/jARYXlCSjQksTBQcJ0HFUPOO79EPPH5JS6VAhiIQbycf0O3JAxQ==}
@@ -12943,11 +12896,9 @@ packages:
   /source-map/0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-    dev: false
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    dev: false
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -13013,7 +12964,6 @@ packages:
   /split-on-first/1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
-    dev: false
 
   /split2/3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
@@ -13051,7 +13001,6 @@ packages:
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /string-width/1.0.2:
     resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=, tarball: string-width/download/string-width-1.0.2.tgz}
@@ -13060,7 +13009,6 @@ packages:
       code-point-at: 1.1.0
       is-fullwidth-code-point: 1.0.0
       strip-ansi: 3.0.1
-    dev: false
 
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -13139,7 +13087,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
-    dev: false
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -13606,7 +13553,6 @@ packages:
       mylas: 2.1.13
       normalize-path: 3.0.0
       plimit-lit: 1.5.0
-    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -14589,7 +14535,6 @@ packages:
     resolution: {integrity: sha1-3x1MIGhUNp7PPJpImPGyP72dFdM=, tarball: wide-align/download/wide-align-1.1.5.tgz}
     dependencies:
       string-width: 4.2.3
-    dev: false
 
   /widest-line/3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,7 @@ importers:
       '@docusaurus/preset-classic': ^2.0.1
       '@docusaurus/theme-common': ^2.2.0
       '@easyops-cn/docusaurus-search-local': ^0.33.6
+      '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg-plugin-docusaurus': ^1.4.2
       '@mdx-js/react': ^1.6.22
       '@tsconfig/docusaurus': ^1.0.5
@@ -355,6 +356,7 @@ importers:
       '@algolia/client-search': 4.13.1
       '@docusaurus/module-type-aliases': 2.0.1_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/theme-common': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
       '@ice/pkg-plugin-docusaurus': 1.4.2_tamhlxc7qrywbuihnmn3loh2be
       '@tsconfig/docusaurus': 1.0.6
       '@types/react': 17.0.52
@@ -2057,6 +2059,7 @@ packages:
   /@discoveryjs/json-ext/0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+    dev: true
 
   /@docsearch/css/3.1.1:
     resolution: {integrity: sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg==}
@@ -2370,7 +2373,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: true
 
   /@docusaurus/core/2.2.0_aeigrxhfhc4abyd45ix2hknizy:
     resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
@@ -2761,6 +2763,7 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
+    dev: false
 
   /@docusaurus/cssnano-preset/2.0.1:
     resolution: {integrity: sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==}
@@ -4733,7 +4736,6 @@ packages:
     dependencies:
       react: 17.0.2
       style-unit: 3.0.5
-    dev: false
 
   /@ice/pkg-plugin-docusaurus/1.4.2_tamhlxc7qrywbuihnmn3loh2be:
     resolution: {integrity: sha512-hxMB82ewnzk5Zj/1/o12bKl7TCGGUuoBirYrwadWQeNm5wVKHy4GyZipgw8qvWkY4Z0ar+eFF+F5sQFEmmUQog==}
@@ -6139,6 +6141,7 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.73.0
+    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -6147,6 +6150,7 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0_webpack@5.73.0
+    dev: true
 
   /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -6158,6 +6162,7 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0_webpack@5.73.0
+    dev: true
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -7753,9 +7758,9 @@ packages:
       less: '>=4.0.0'
       less-loader: '>=10.0.0'
     dependencies:
-      '@docusaurus/core': 2.2.0_wfh3mw2ke2bdr53qfq544ltemu
+      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
       less: 4.1.3
-      less-loader: 11.0.0_less@4.1.3+webpack@5.75.0
+      less-loader: 11.0.0_less@4.1.3
 
   /docusaurus-plugin-sass/0.2.2_6wqf4cuv72z6apsq26qakw4k4e:
     resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
@@ -7949,6 +7954,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /errno/0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
@@ -8633,6 +8639,7 @@ packages:
 
   /fastest-levenshtein/1.0.12:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
+    dev: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -8891,6 +8898,7 @@ packages:
       tapable: 1.1.3
       typescript: 4.9.3
       webpack: 5.75.0
+    dev: false
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -9615,6 +9623,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -9687,6 +9696,7 @@ packages:
   /interpret/2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /invariant/2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -10204,7 +10214,6 @@ packages:
     dependencies:
       klona: 2.0.5
       less: 4.1.3
-    dev: true
 
   /less-loader/11.0.0_less@4.1.3+webpack@5.75.0:
     resolution: {integrity: sha512-9+LOWWjuoectIEx3zrfN83NAGxSUB5pWEabbbidVQVgZhN+wN68pOvuyirVlH1IK4VT1f3TmlyvAnCXh8O5KEw==}
@@ -10216,6 +10225,7 @@ packages:
       klona: 2.0.5
       less: 4.1.3
       webpack: 5.75.0
+    dev: false
 
   /less/4.1.3:
     resolution: {integrity: sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==}
@@ -12285,6 +12295,7 @@ packages:
       - eslint
       - supports-color
       - vue-template-compiler
+    dev: false
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -12514,6 +12525,7 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.1
+    dev: true
 
   /recursive-readdir/2.2.2:
     resolution: {integrity: sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==}
@@ -12743,6 +12755,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -12751,6 +12764,7 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-global/1.0.0:
     resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
@@ -13778,7 +13792,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.1
-      webpack: 5.73.0_webpack-cli@4.10.0
+      webpack: 5.73.0
 
   /terser-webpack-plugin/5.3.3_webpack@5.75.0:
     resolution: {integrity: sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==}
@@ -14620,6 +14634,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-dev-middleware/5.3.3_webpack@5.75.0:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -14818,6 +14833,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.75.0:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
       '@docusaurus/preset-classic': ^2.0.1
       '@docusaurus/theme-common': ^2.2.0
       '@easyops-cn/docusaurus-search-local': ^0.33.6
-      '@ice/pkg-plugin-docusaurus': workspace:*
+      '@ice/pkg-plugin-docusaurus': ^1.4.2
       '@mdx-js/react': ^1.6.22
       '@tsconfig/docusaurus': ^1.0.5
       '@types/react': ^17.0.0
@@ -355,7 +355,7 @@ importers:
       '@algolia/client-search': 4.13.1
       '@docusaurus/module-type-aliases': 2.0.1_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/theme-common': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
-      '@ice/pkg-plugin-docusaurus': link:../packages/plugin-docusaurus
+      '@ice/pkg-plugin-docusaurus': 1.4.2_tamhlxc7qrywbuihnmn3loh2be
       '@tsconfig/docusaurus': 1.0.6
       '@types/react': 17.0.52
       typescript: 4.7.4
@@ -366,7 +366,6 @@ packages:
     resolution: {integrity: sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==}
     dependencies:
       '@algolia/autocomplete-shared': 1.7.1
-    dev: false
 
   /@algolia/autocomplete-preset-algolia/1.7.1_jr4xm7x4v4vd7iifhnoo3rb33u:
     resolution: {integrity: sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==}
@@ -377,17 +376,14 @@ packages:
       '@algolia/autocomplete-shared': 1.7.1
       '@algolia/client-search': 4.13.1
       algoliasearch: 4.13.1
-    dev: false
 
   /@algolia/autocomplete-shared/1.7.1:
     resolution: {integrity: sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg==}
-    dev: false
 
   /@algolia/cache-browser-local-storage/4.13.1:
     resolution: {integrity: sha512-UAUVG2PEfwd/FfudsZtYnidJ9eSCpS+LW9cQiesePQLz41NAcddKxBak6eP2GErqyFagSlnVXe/w2E9h2m2ttg==}
     dependencies:
       '@algolia/cache-common': 4.13.1
-    dev: false
 
   /@algolia/cache-common/4.13.1:
     resolution: {integrity: sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA==}
@@ -396,7 +392,6 @@ packages:
     resolution: {integrity: sha512-pZzybCDGApfA/nutsFK1P0Sbsq6fYJU3DwIvyKg4pURerlJM4qZbB9bfLRef0FkzfQu7W11E4cVLCIOWmyZeuQ==}
     dependencies:
       '@algolia/cache-common': 4.13.1
-    dev: false
 
   /@algolia/client-account/4.13.1:
     resolution: {integrity: sha512-TFLiZ1KqMiir3FNHU+h3b0MArmyaHG+eT8Iojio6TdpeFcAQ1Aiy+2gb3SZk3+pgRJa/BxGmDkRUwE5E/lv3QQ==}
@@ -404,7 +399,6 @@ packages:
       '@algolia/client-common': 4.13.1
       '@algolia/client-search': 4.13.1
       '@algolia/transporter': 4.13.1
-    dev: false
 
   /@algolia/client-analytics/4.13.1:
     resolution: {integrity: sha512-iOS1JBqh7xaL5x00M5zyluZ9+9Uy9GqtYHv/2SMuzNW1qP7/0doz1lbcsP3S7KBbZANJTFHUOfuqyRLPk91iFA==}
@@ -413,7 +407,6 @@ packages:
       '@algolia/client-search': 4.13.1
       '@algolia/requester-common': 4.13.1
       '@algolia/transporter': 4.13.1
-    dev: false
 
   /@algolia/client-common/4.13.1:
     resolution: {integrity: sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==}
@@ -427,7 +420,6 @@ packages:
       '@algolia/client-common': 4.13.1
       '@algolia/requester-common': 4.13.1
       '@algolia/transporter': 4.13.1
-    dev: false
 
   /@algolia/client-search/4.13.1:
     resolution: {integrity: sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==}
@@ -438,7 +430,6 @@ packages:
 
   /@algolia/events/4.0.1:
     resolution: {integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==}
-    dev: false
 
   /@algolia/logger-common/4.13.1:
     resolution: {integrity: sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw==}
@@ -447,13 +438,11 @@ packages:
     resolution: {integrity: sha512-7jQOTftfeeLlnb3YqF8bNgA2GZht7rdKkJ31OCeSH2/61haO0tWPoNRjZq9XLlgMQZH276pPo0NdiArcYPHjCA==}
     dependencies:
       '@algolia/logger-common': 4.13.1
-    dev: false
 
   /@algolia/requester-browser-xhr/4.13.1:
     resolution: {integrity: sha512-oa0CKr1iH6Nc7CmU6RE7TnXMjHnlyp7S80pP/LvZVABeJHX3p/BcSCKovNYWWltgTxUg0U1o+2uuy8BpMKljwA==}
     dependencies:
       '@algolia/requester-common': 4.13.1
-    dev: false
 
   /@algolia/requester-common/4.13.1:
     resolution: {integrity: sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w==}
@@ -462,7 +451,6 @@ packages:
     resolution: {integrity: sha512-7C0skwtLdCz5heKTVe/vjvrqgL/eJxmiEjHqXdtypcE5GCQCYI15cb+wC4ytYioZDMiuDGeVYmCYImPoEgUGPw==}
     dependencies:
       '@algolia/requester-common': 4.13.1
-    dev: false
 
   /@algolia/transporter/4.13.1:
     resolution: {integrity: sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==}
@@ -2072,7 +2060,6 @@ packages:
 
   /@docsearch/css/3.1.1:
     resolution: {integrity: sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg==}
-    dev: false
 
   /@docsearch/react/3.1.1_c6kcmqf4p25qrgl2rpjskujhsi:
     resolution: {integrity: sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==}
@@ -2090,7 +2077,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
       - '@algolia/client-search'
-    dev: false
 
   /@docusaurus/core/2.0.1_3tgeifm2vmwrlpqlopppsnjtcu:
     resolution: {integrity: sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==}
@@ -2287,6 +2273,104 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/core/2.2.0_3tgeifm2vmwrlpqlopppsnjtcu:
+    resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/generator': 7.18.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.6
+      '@babel/plugin-transform-runtime': 7.18.6_@babel+core@7.18.6
+      '@babel/preset-env': 7.18.6_@babel+core@7.18.6
+      '@babel/preset-react': 7.18.6_@babel+core@7.18.6
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.6
+      '@babel/runtime': 7.18.6
+      '@babel/runtime-corejs3': 7.18.6
+      '@babel/traverse': 7.18.8
+      '@docusaurus/cssnano-preset': 2.2.0
+      '@docusaurus/logger': 2.2.0
+      '@docusaurus/mdx-loader': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/react-loadable': 5.5.2_react@17.0.2
+      '@docusaurus/utils': 2.2.0
+      '@docusaurus/utils-common': 2.2.0
+      '@docusaurus/utils-validation': 2.2.0
+      '@slorber/static-site-generator-webpack-plugin': 4.0.7
+      '@svgr/webpack': 6.2.1
+      autoprefixer: 10.4.7_postcss@8.4.14
+      babel-loader: 8.2.5_o3r2xgxvdoyfhb4elbs6lcfrlu
+      babel-plugin-dynamic-import-node: 2.3.3
+      boxen: 6.2.1
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      clean-css: 5.3.0
+      cli-table3: 0.6.2
+      combine-promises: 1.1.0
+      commander: 5.1.0
+      copy-webpack-plugin: 11.0.0_webpack@5.75.0
+      core-js: 3.23.4
+      css-loader: 6.7.1_webpack@5.75.0
+      css-minimizer-webpack-plugin: 4.0.0_zut7kw46oefpa7zgeqrbpwozya
+      cssnano: 5.1.12_postcss@8.4.14
+      del: 6.1.1
+      detect-port: 1.3.0
+      escape-html: 1.0.3
+      eta: 1.12.3
+      file-loader: 6.2.0_webpack@5.75.0
+      fs-extra: 10.1.0
+      html-minifier-terser: 6.1.0
+      html-tags: 3.2.0
+      html-webpack-plugin: 5.5.0_webpack@5.75.0
+      import-fresh: 3.3.0
+      leven: 3.1.0
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.6.1_webpack@5.75.0
+      postcss: 8.4.14
+      postcss-loader: 7.0.0_yr6womevqv5t3aet2t3y7pv3ua
+      prompts: 2.4.2
+      react: 17.0.2
+      react-dev-utils: 12.0.1_l2co7ao223gzrfox7yaiyzd7wu
+      react-dom: 17.0.2_react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_pwfl7zyferpbeh35vaepqxwaky
+      react-router: 5.3.3_react@17.0.2
+      react-router-config: 5.1.1_oyuskl3t7voyrff2xstzuy4hqu
+      react-router-dom: 5.3.3_react@17.0.2
+      rtl-detect: 1.0.4
+      semver: 7.3.7
+      serve-handler: 6.1.3
+      shelljs: 0.8.5
+      terser-webpack-plugin: 5.3.3_webpack@5.75.0
+      tslib: 2.4.0
+      update-notifier: 5.1.0
+      url-loader: 4.1.1_p5dl6emkcwslbw72e37w4ug7em
+      wait-on: 6.0.1
+      webpack: 5.75.0
+      webpack-bundle-analyzer: 4.5.0
+      webpack-dev-server: 4.9.3_webpack@5.75.0
+      webpack-merge: 5.8.0
+      webpackbar: 5.0.2_webpack@5.75.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/core/2.2.0_aeigrxhfhc4abyd45ix2hknizy:
     resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
@@ -2677,7 +2761,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-    dev: false
 
   /@docusaurus/cssnano-preset/2.0.1:
     resolution: {integrity: sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==}
@@ -3344,6 +3427,39 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/plugin-debug/2.2.0_rglzyuwjmbibx7tnak3av4hvt4:
+    resolution: {integrity: sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      fs-extra: 10.1.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-json-view: 1.21.3_gzv7pa6nrbev3fs6gyzn7sadkq
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - '@types/react'
+      - bufferutil
+      - csso
+      - debug
+      - encoding
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
+
   /@docusaurus/plugin-google-analytics/2.0.1_3tgeifm2vmwrlpqlopppsnjtcu:
     resolution: {integrity: sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==}
     engines: {node: '>=16.14'}
@@ -3372,6 +3488,35 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/plugin-google-analytics/2.2.0_3tgeifm2vmwrlpqlopppsnjtcu:
+    resolution: {integrity: sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/plugin-google-analytics/2.2.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==}
@@ -3430,6 +3575,35 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/plugin-google-gtag/2.2.0_3tgeifm2vmwrlpqlopppsnjtcu:
+    resolution: {integrity: sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/plugin-google-gtag/2.2.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==}
@@ -3493,6 +3667,40 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/plugin-sitemap/2.2.0_3tgeifm2vmwrlpqlopppsnjtcu:
+    resolution: {integrity: sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/logger': 2.2.0
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      fs-extra: 10.1.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      sitemap: 7.1.1
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/plugin-sitemap/2.2.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==}
@@ -3567,6 +3775,46 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/preset-classic/2.2.0_tamhlxc7qrywbuihnmn3loh2be:
+    resolution: {integrity: sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/plugin-content-blog': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-docs': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-pages': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-debug': 2.2.0_rglzyuwjmbibx7tnak3av4hvt4
+      '@docusaurus/plugin-google-analytics': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-google-gtag': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-sitemap': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/theme-classic': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/theme-common': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/theme-search-algolia': 2.2.0_qjmc7u5hculwzstel6kzrdwhia
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@types/react'
+      - bufferutil
+      - csso
+      - debug
+      - encoding
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/preset-classic/2.2.0_zj3epevdq6d4ikykdk7jwyp4wa:
     resolution: {integrity: sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==}
@@ -3666,6 +3914,56 @@ packages:
       - vue-template-compiler
       - webpack-cli
     dev: false
+
+  /@docusaurus/theme-classic/2.2.0_3tgeifm2vmwrlpqlopppsnjtcu:
+    resolution: {integrity: sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
+      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-docs': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-pages': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/theme-common': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/theme-translations': 2.2.0
+      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@mdx-js/react': 1.6.22_react@17.0.2
+      clsx: 1.2.1
+      copy-text-to-clipboard: 3.0.1
+      infima: 0.2.0-alpha.42
+      lodash: 4.17.21
+      nprogress: 0.2.0
+      postcss: 8.4.14
+      prism-react-renderer: 1.3.5_react@17.0.2
+      prismjs: 1.28.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.3.3_react@17.0.2
+      rtlcss: 3.5.0
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
 
   /@docusaurus/theme-classic/2.2.0_wfh3mw2ke2bdr53qfq544ltemu:
     resolution: {integrity: sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==}
@@ -3836,6 +4134,46 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/theme-common/2.2.0_e4pyalr7znoa3t23syhqu25gga:
+    resolution: {integrity: sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
+      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-docs': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/plugin-content-pages': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@types/history': 4.7.11
+      '@types/react': 18.0.15
+      '@types/react-router-config': 5.0.6
+      clsx: 1.2.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 1.3.5_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
+
   /@docusaurus/theme-search-algolia/2.0.1_6mbiwgwtnizktannfihsquztb4:
     resolution: {integrity: sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==}
     engines: {node: '>=16.14'}
@@ -3924,6 +4262,50 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/theme-search-algolia/2.2.0_qjmc7u5hculwzstel6kzrdwhia:
+    resolution: {integrity: sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docsearch/react': 3.1.1_c6kcmqf4p25qrgl2rpjskujhsi
+      '@docusaurus/core': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/logger': 2.2.0
+      '@docusaurus/plugin-content-docs': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/theme-common': 2.2.0_e4pyalr7znoa3t23syhqu25gga
+      '@docusaurus/theme-translations': 2.2.0
+      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      algoliasearch: 4.13.1
+      algoliasearch-helper: 3.10.0_algoliasearch@4.13.1
+      clsx: 1.2.1
+      eta: 1.12.3
+      fs-extra: 10.1.0
+      lodash: 4.17.21
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@types/react'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: true
+
   /@docusaurus/theme-translations/2.0.1:
     resolution: {integrity: sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==}
     engines: {node: '>=16.14'}
@@ -3938,7 +4320,6 @@ packages:
     dependencies:
       fs-extra: 10.1.0
       tslib: 2.4.0
-    dev: false
 
   /@docusaurus/types/2.0.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==}
@@ -4019,7 +4400,6 @@ packages:
         optional: true
     dependencies:
       tslib: 2.4.0
-    dev: false
 
   /@docusaurus/utils-common/2.2.0_@docusaurus+types@2.2.0:
     resolution: {integrity: sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==}
@@ -4085,7 +4465,6 @@ packages:
       - supports-color
       - uglify-js
       - webpack-cli
-    dev: false
 
   /@docusaurus/utils-validation/2.2.0_@docusaurus+types@2.2.0:
     resolution: {integrity: sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==}
@@ -4356,6 +4735,63 @@ packages:
       style-unit: 3.0.5
     dev: false
 
+  /@ice/pkg-plugin-docusaurus/1.4.2_tamhlxc7qrywbuihnmn3loh2be:
+    resolution: {integrity: sha512-hxMB82ewnzk5Zj/1/o12bKl7TCGGUuoBirYrwadWQeNm5wVKHy4GyZipgw8qvWkY4Z0ar+eFF+F5sQFEmmUQog==}
+    dependencies:
+      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      '@docusaurus/preset-classic': 2.2.0_tamhlxc7qrywbuihnmn3loh2be
+      '@mdx-js/react': 1.6.22_react@17.0.2
+      '@swc/helpers': 0.4.14
+      address: 1.2.1
+      consola: 2.15.3
+      copy-text-to-clipboard: 3.0.1
+      detect-port: 1.3.0
+      directory-tree: 3.3.1
+      docusaurus-plugin-less: 2.0.2_h7k4fbmhvh7tyycryrahgmkyge
+      docusaurus-plugin-sass: 0.2.2_6wqf4cuv72z6apsq26qakw4k4e
+      es-module-lexer: 0.10.5
+      fs-extra: 10.1.0
+      handlebars: 4.7.7
+      hast-util-find-and-replace: 3.2.1
+      less: 4.1.3
+      less-loader: 11.0.0_less@4.1.3
+      postcss-plugin-rpx2vw: 0.0.3
+      prism-react-renderer: 1.3.5_react@17.0.2
+      qrcode.react: 3.1.0_react@17.0.2
+      react-tooltip: 4.2.21_sfoxds7t5ydpegc3knd667wn6m
+      remark-parse: 10.0.1
+      remark-stringify: 10.0.2
+      sass: 1.53.0
+      sass-loader: 12.6.0_sass@1.53.0
+      style-unit: 3.0.5
+      unified: 10.1.2
+      unist-util-visit: 2.0.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@types/react'
+      - bufferutil
+      - csso
+      - debug
+      - encoding
+      - esbuild
+      - eslint
+      - fibers
+      - node-sass
+      - react
+      - react-dom
+      - sass-embedded
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+    dev: true
+
   /@ice/pkg/1.4.1:
     resolution: {integrity: sha512-j0Ib6ecDPWMEvt3QtNLQnwVyXtOQYPUmbvG6UG1CfjwQ3WOwe/QVa/dxNKbwUxkcZqZrlQ5IuQsP3gvN2Hjjwg==}
     engines: {node: '>=16.0.0'}
@@ -4570,7 +5006,6 @@ packages:
       react: ^16.13.1 || ^17.0.0
     dependencies:
       react: 17.0.2
-    dev: false
 
   /@mdx-js/util/1.6.22:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
@@ -5150,7 +5585,6 @@ packages:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.4.0
-    dev: false
 
   /@swc/helpers/0.4.3:
     resolution: {integrity: sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==}
@@ -5261,7 +5695,6 @@ packages:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
       '@types/ms': 0.7.31
-    dev: false
 
   /@types/eslint-scope/3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
@@ -5359,7 +5792,6 @@ packages:
 
   /@types/ms/0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
-    dev: false
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -5447,7 +5879,6 @@ packages:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
       '@types/node': 18.0.3
-    dev: false
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
@@ -5844,7 +6275,6 @@ packages:
     dependencies:
       '@algolia/events': 4.0.1
       algoliasearch: 4.13.1
-    dev: false
 
   /algoliasearch/4.13.1:
     resolution: {integrity: sha512-dtHUSE0caWTCE7liE1xaL+19AFf6kWEcyn76uhcitWpntqvicFHXKFoZe5JJcv9whQOTRM6+B8qJz6sFj+rDJA==}
@@ -5863,7 +6293,6 @@ packages:
       '@algolia/requester-common': 4.13.1
       '@algolia/requester-node-http': 4.13.1
       '@algolia/transporter': 4.13.1
-    dev: false
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -5936,7 +6365,6 @@ packages:
 
   /arg/5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: false
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -5949,12 +6377,10 @@ packages:
   /array-back/3.1.0:
     resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /array-back/4.0.2:
     resolution: {integrity: sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==}
     engines: {node: '>=8'}
-    dev: false
 
   /array-flatten/1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -6008,7 +6434,6 @@ packages:
 
   /asap/2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
-    dev: false
 
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -6149,7 +6574,6 @@ packages:
 
   /bail/2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
-    dev: false
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -6160,7 +6584,6 @@ packages:
 
   /base16/1.0.0:
     resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
-    dev: false
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6453,7 +6876,6 @@ packages:
 
   /character-entities/2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-    dev: false
 
   /character-reference-invalid/1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
@@ -6649,7 +7071,6 @@ packages:
       find-replace: 3.0.0
       lodash.camelcase: 4.3.0
       typical: 4.0.0
-    dev: false
 
   /command-line-usage/6.1.3:
     resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
@@ -6659,7 +7080,6 @@ packages:
       chalk: 2.4.2
       table-layout: 1.0.2
       typical: 5.2.0
-    dev: false
 
   /commander/2.20.3:
     resolution: {integrity: sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=, tarball: commander/download/commander-2.20.3.tgz}
@@ -6800,12 +7220,10 @@ packages:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
     dependencies:
       is-what: 3.14.1
-    dev: false
 
   /copy-text-to-clipboard/3.0.1:
     resolution: {integrity: sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==}
     engines: {node: '>=12'}
-    dev: false
 
   /copy-webpack-plugin/11.0.0_webpack@5.75.0:
     resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
@@ -6874,7 +7292,6 @@ packages:
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /cross-spawn/5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -7164,7 +7581,6 @@ packages:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
     dependencies:
       character-entities: 2.0.2
-    dev: false
 
   /decode-uri-component/0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -7247,7 +7663,6 @@ packages:
   /dequal/2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-    dev: false
 
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -7293,7 +7708,6 @@ packages:
   /diff/5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
-    dev: false
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -7308,7 +7722,6 @@ packages:
     dependencies:
       command-line-args: 5.2.1
       command-line-usage: 6.1.3
-    dev: false
 
   /dns-equal/1.0.0:
     resolution: {integrity: sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==}
@@ -7343,7 +7756,21 @@ packages:
       '@docusaurus/core': 2.2.0_wfh3mw2ke2bdr53qfq544ltemu
       less: 4.1.3
       less-loader: 11.0.0_less@4.1.3+webpack@5.75.0
-    dev: false
+
+  /docusaurus-plugin-sass/0.2.2_6wqf4cuv72z6apsq26qakw4k4e:
+    resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
+    peerDependencies:
+      '@docusaurus/core': ^2.0.0-beta
+      sass: ^1.30.0
+    dependencies:
+      '@docusaurus/core': 2.2.0_3tgeifm2vmwrlpqlopppsnjtcu
+      sass: 1.53.0
+      sass-loader: 10.3.1_sass@1.53.0
+    transitivePeerDependencies:
+      - fibers
+      - node-sass
+      - webpack
+    dev: true
 
   /docusaurus-plugin-sass/0.2.2_o4svcqyokigxau2zur67axle74:
     resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
@@ -7529,7 +7956,6 @@ packages:
     requiresBuild: true
     dependencies:
       prr: 1.0.1
-    dev: false
     optional: true
 
   /error-ex/1.3.2:
@@ -7568,7 +7994,6 @@ packages:
 
   /es-module-lexer/0.10.5:
     resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
-    dev: false
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
@@ -8226,11 +8651,9 @@ packages:
       fbjs: 3.0.4
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /fbjs-css-vars/1.0.2:
     resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
-    dev: false
 
   /fbjs/3.0.4:
     resolution: {integrity: sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==}
@@ -8244,7 +8667,6 @@ packages:
       ua-parser-js: 0.7.31
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /feed/4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
@@ -8323,7 +8745,6 @@ packages:
     engines: {node: '>=4.0.0'}
     dependencies:
       array-back: 3.1.0
-    dev: false
 
   /find-up/2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -8381,7 +8802,6 @@ packages:
       react: 17.0.2
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /follow-redirects/1.15.1:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
@@ -8471,7 +8891,6 @@ packages:
       tapable: 1.1.3
       typescript: 4.9.3
       webpack: 5.75.0
-    dev: false
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -8793,7 +9212,6 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.16.2
-    dev: false
 
   /hard-rejection/2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -8858,7 +9276,6 @@ packages:
       escape-string-regexp: 4.0.0
       hast-util-is-element: 1.1.0
       unist-util-visit-parents: 3.1.1
-    dev: false
 
   /hast-util-from-parse5/6.0.1:
     resolution: {integrity: sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==}
@@ -8872,7 +9289,6 @@ packages:
 
   /hast-util-is-element/1.1.0:
     resolution: {integrity: sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==}
-    dev: false
 
   /hast-util-parse-selector/2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
@@ -9134,7 +9550,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
     optional: true
 
   /icss-utils/5.1.0_postcss@8.4.14:
@@ -9158,7 +9573,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /image-size/1.0.1:
@@ -9213,7 +9627,6 @@ packages:
   /infima/0.2.0-alpha.42:
     resolution: {integrity: sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==}
     engines: {node: '>=12'}
-    dev: false
 
   /inflight/1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -9467,7 +9880,6 @@ packages:
   /is-plain-obj/4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-    dev: false
 
   /is-plain-object/2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -9554,7 +9966,6 @@ packages:
 
   /is-what/3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
-    dev: false
 
   /is-whitespace-character/1.0.4:
     resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
@@ -9784,6 +10195,17 @@ packages:
       invert-kv: 3.0.1
     dev: false
 
+  /less-loader/11.0.0_less@4.1.3:
+    resolution: {integrity: sha512-9+LOWWjuoectIEx3zrfN83NAGxSUB5pWEabbbidVQVgZhN+wN68pOvuyirVlH1IK4VT1f3TmlyvAnCXh8O5KEw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      less: ^3.5.0 || ^4.0.0
+      webpack: ^5.0.0
+    dependencies:
+      klona: 2.0.5
+      less: 4.1.3
+    dev: true
+
   /less-loader/11.0.0_less@4.1.3+webpack@5.75.0:
     resolution: {integrity: sha512-9+LOWWjuoectIEx3zrfN83NAGxSUB5pWEabbbidVQVgZhN+wN68pOvuyirVlH1IK4VT1f3TmlyvAnCXh8O5KEw==}
     engines: {node: '>= 14.15.0'}
@@ -9794,7 +10216,6 @@ packages:
       klona: 2.0.5
       less: 4.1.3
       webpack: 5.75.0
-    dev: false
 
   /less/4.1.3:
     resolution: {integrity: sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==}
@@ -9814,7 +10235,6 @@ packages:
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -9912,18 +10332,15 @@ packages:
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-    dev: false
 
   /lodash.curry/4.1.1:
     resolution: {integrity: sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==}
-    dev: false
 
   /lodash.debounce/4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   /lodash.flow/3.5.0:
     resolution: {integrity: sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==}
-    dev: false
 
   /lodash.get/4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
@@ -9970,7 +10387,6 @@ packages:
 
   /longest-streak/3.0.1:
     resolution: {integrity: sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==}
-    dev: false
 
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -10036,7 +10452,6 @@ packages:
     dependencies:
       pify: 4.0.1
       semver: 5.7.1
-    dev: false
     optional: true
 
   /make-dir/3.1.0:
@@ -10108,7 +10523,6 @@ packages:
       uvu: 0.5.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /mdast-util-to-hast/10.0.1:
     resolution: {integrity: sha512-BW3LM9SEMnjf4HXXVApZMt8gLQWVNXc3jryK0nJu/rOXPOnlkUjmdkDlmxMirpbU9ILncGFIwLH/ubnWBbcdgA==}
@@ -10143,14 +10557,12 @@ packages:
       micromark-util-decode-string: 1.0.2
       unist-util-visit: 4.1.1
       zwitch: 2.0.2
-    dev: false
 
   /mdast-util-to-string/2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
 
   /mdast-util-to-string/3.1.0:
     resolution: {integrity: sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==}
-    dev: false
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -10258,7 +10670,6 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
-    dev: false
 
   /micromark-factory-destination/1.0.0:
     resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
@@ -10266,7 +10677,6 @@ packages:
       micromark-util-character: 1.1.0
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-factory-label/1.0.2:
     resolution: {integrity: sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==}
@@ -10275,14 +10685,12 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
-    dev: false
 
   /micromark-factory-space/1.0.0:
     resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
     dependencies:
       micromark-util-character: 1.1.0
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-factory-title/1.0.2:
     resolution: {integrity: sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==}
@@ -10292,7 +10700,6 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
-    dev: false
 
   /micromark-factory-whitespace/1.0.0:
     resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
@@ -10301,20 +10708,17 @@ packages:
       micromark-util-character: 1.1.0
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-util-character/1.1.0:
     resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
     dependencies:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-util-chunked/1.0.0:
     resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
     dependencies:
       micromark-util-symbol: 1.0.1
-    dev: false
 
   /micromark-util-classify-character/1.0.0:
     resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
@@ -10322,20 +10726,17 @@ packages:
       micromark-util-character: 1.1.0
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-util-combine-extensions/1.0.0:
     resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
     dependencies:
       micromark-util-chunked: 1.0.0
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-util-decode-numeric-character-reference/1.0.0:
     resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
     dependencies:
       micromark-util-symbol: 1.0.1
-    dev: false
 
   /micromark-util-decode-string/1.0.2:
     resolution: {integrity: sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==}
@@ -10344,27 +10745,22 @@ packages:
       micromark-util-character: 1.1.0
       micromark-util-decode-numeric-character-reference: 1.0.0
       micromark-util-symbol: 1.0.1
-    dev: false
 
   /micromark-util-encode/1.0.1:
     resolution: {integrity: sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==}
-    dev: false
 
   /micromark-util-html-tag-name/1.1.0:
     resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
-    dev: false
 
   /micromark-util-normalize-identifier/1.0.0:
     resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
     dependencies:
       micromark-util-symbol: 1.0.1
-    dev: false
 
   /micromark-util-resolve-all/1.0.0:
     resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
     dependencies:
       micromark-util-types: 1.0.2
-    dev: false
 
   /micromark-util-sanitize-uri/1.0.0:
     resolution: {integrity: sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==}
@@ -10372,7 +10768,6 @@ packages:
       micromark-util-character: 1.1.0
       micromark-util-encode: 1.0.1
       micromark-util-symbol: 1.0.1
-    dev: false
 
   /micromark-util-subtokenize/1.0.2:
     resolution: {integrity: sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==}
@@ -10381,15 +10776,12 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
-    dev: false
 
   /micromark-util-symbol/1.0.1:
     resolution: {integrity: sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==}
-    dev: false
 
   /micromark-util-types/1.0.2:
     resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
-    dev: false
 
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
@@ -10422,7 +10814,6 @@ packages:
       uvu: 0.5.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /micromatch/4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -10554,7 +10945,6 @@ packages:
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: false
 
   /mrmime/1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
@@ -10604,7 +10994,6 @@ packages:
       sax: 1.2.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
     optional: true
 
   /negotiator/0.6.3:
@@ -10639,7 +11028,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
   /node-forge/1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -10719,7 +11107,6 @@ packages:
 
   /nprogress/0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
-    dev: false
 
   /nth-check/2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -11030,7 +11417,6 @@ packages:
   /parse-node-version/1.0.1:
     resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==}
     engines: {node: '>= 0.10'}
-    dev: false
 
   /parse-numeric-range/1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
@@ -11470,7 +11856,6 @@ packages:
     resolution: {integrity: sha512-AxlNldVz3ECNqkyJOuytVAERQxkb2512XIOBIBHq/LvbrvmvvWrH10qIilEiBQ1ECxsQVhqO5lYtRIdg6e9iQA==}
     dependencies:
       postcss: 7.0.39
-    dev: false
 
   /postcss-reduce-idents/5.2.0_postcss@8.4.14:
     resolution: {integrity: sha512-BTrLjICoSB6gxbc58D5mdBK8OhXRDqud/zodYfdSi52qvDHdMwk+9kB9xsM8yJThH/sZU5A6QVSmMmaN001gIg==}
@@ -11658,7 +12043,6 @@ packages:
   /prismjs/1.28.0:
     resolution: {integrity: sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==}
     engines: {node: '>=6'}
-    dev: false
 
   /process-nextick-args/2.0.1:
     resolution: {integrity: sha1-eCDZsWEgzFXKmud5JoCufbptf+I=, tarball: process-nextick-args/download/process-nextick-args-2.0.1.tgz}
@@ -11667,7 +12051,6 @@ packages:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
     dependencies:
       asap: 2.0.6
-    dev: false
 
   /prompts/2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -11697,7 +12080,6 @@ packages:
 
   /prr/1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
-    dev: false
     optional: true
 
   /pseudomap/1.0.2:
@@ -11725,7 +12107,6 @@ packages:
 
   /pure-color/1.3.0:
     resolution: {integrity: sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==}
-    dev: false
 
   /q/1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -11738,7 +12119,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 17.0.2
-    dev: false
 
   /qs/6.10.3:
     resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
@@ -11823,7 +12203,6 @@ packages:
       lodash.curry: 4.1.1
       lodash.flow: 3.5.0
       pure-color: 1.3.0
-    dev: false
 
   /react-dev-utils/12.0.1_l2co7ao223gzrfox7yaiyzd7wu:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
@@ -11906,7 +12285,6 @@ packages:
       - eslint
       - supports-color
       - vue-template-compiler
-    dev: false
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -11965,11 +12343,9 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - encoding
-    dev: false
 
   /react-lifecycles-compat/3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
-    dev: false
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_pwfl7zyferpbeh35vaepqxwaky:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
@@ -12035,7 +12411,6 @@ packages:
       use-latest: 1.2.1_q5o373oqrklnndq2vhekyuzhxi
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /react-tooltip/4.2.21_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==}
@@ -12048,7 +12423,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       uuid: 7.0.3
-    dev: false
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -12158,7 +12532,6 @@ packages:
   /reduce-flatten/2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
-    dev: false
 
   /regenerate-unicode-properties/10.0.1:
     resolution: {integrity: sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==}
@@ -12262,7 +12635,6 @@ packages:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /remark-parse/8.0.3:
     resolution: {integrity: sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==}
@@ -12303,7 +12675,6 @@ packages:
       '@types/mdast': 3.0.10
       mdast-util-to-markdown: 1.3.0
       unified: 10.1.2
-    dev: false
 
   /remark-stringify/9.0.1:
     resolution: {integrity: sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==}
@@ -12494,7 +12865,6 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.14
       strip-json-comments: 3.1.1
-    dev: false
 
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -12516,7 +12886,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mri: 1.2.0
-    dev: false
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -12526,6 +12895,30 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  /sass-loader/10.3.1_sass@1.53.0:
+    resolution: {integrity: sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      fibers: '>= 3.1.0'
+      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      sass: ^1.3.0
+      webpack: ^4.36.0 || ^5.0.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      klona: 2.0.5
+      loader-utils: 2.0.2
+      neo-async: 2.6.2
+      sass: 1.53.0
+      schema-utils: 3.1.1
+      semver: 7.3.7
+    dev: true
 
   /sass-loader/10.3.1_sass@1.53.0+webpack@5.75.0:
     resolution: {integrity: sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==}
@@ -12551,6 +12944,30 @@ packages:
       semver: 7.3.7
       webpack: 5.75.0
     dev: false
+
+  /sass-loader/12.6.0_sass@1.53.0:
+    resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      fibers: '>= 3.1.0'
+      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      sass: ^1.3.0
+      sass-embedded: '*'
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+    dependencies:
+      klona: 2.0.5
+      neo-async: 2.6.2
+      sass: 1.53.0
+    dev: true
 
   /sass-loader/12.6.0_sass@1.53.0+webpack@5.75.0:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
@@ -12749,7 +13166,6 @@ packages:
 
   /setimmediate/1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-    dev: false
 
   /setprototypeof/1.1.0:
     resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
@@ -12830,7 +13246,6 @@ packages:
       '@types/sax': 1.2.4
       arg: 5.0.2
       sax: 1.2.4
-    dev: false
 
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -13305,7 +13720,6 @@ packages:
       deep-extend: 0.6.0
       typical: 5.2.0
       wordwrapjs: 4.0.1
-    dev: false
 
   /table/6.8.0:
     resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
@@ -13474,7 +13888,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
 
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -13492,7 +13905,6 @@ packages:
 
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
-    dev: false
 
   /ts-node/10.8.2_x2utdhayajzrh747hktprshhby:
     resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
@@ -13667,23 +14079,19 @@ packages:
   /typical/4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
-    dev: false
 
   /typical/5.2.0:
     resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
     engines: {node: '>=8'}
-    dev: false
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
-    dev: false
 
   /uglify-js/3.16.2:
     resolution: {integrity: sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /unbox-primitive/1.0.2:
@@ -13730,7 +14138,6 @@ packages:
       is-plain-obj: 4.1.0
       trough: 2.1.0
       vfile: 5.3.5
-    dev: false
 
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
@@ -13777,7 +14184,6 @@ packages:
 
   /unist-util-is/5.1.1:
     resolution: {integrity: sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==}
-    dev: false
 
   /unist-util-position/3.1.0:
     resolution: {integrity: sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==}
@@ -13801,7 +14207,6 @@ packages:
     resolution: {integrity: sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==}
     dependencies:
       '@types/unist': 2.0.6
-    dev: false
 
   /unist-util-visit-parents/3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
@@ -13814,7 +14219,6 @@ packages:
     dependencies:
       '@types/unist': 2.0.6
       unist-util-is: 5.1.1
-    dev: false
 
   /unist-util-visit/2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
@@ -13829,7 +14233,6 @@ packages:
       '@types/unist': 2.0.6
       unist-util-is: 5.1.1
       unist-util-visit-parents: 5.1.1
-    dev: false
 
   /universal-env/3.3.3:
     resolution: {integrity: sha512-4ZyITvWhtcurCEA66Cb7jcd4zpEiAAo91wSwbEscbiu033pIsC2yjgT8LYyasFgsst6jZHD1gtVoSyYcL8oH1Q==}
@@ -13915,7 +14318,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 17.0.2
-    dev: false
 
   /use-isomorphic-layout-effect/1.1.2_q5o373oqrklnndq2vhekyuzhxi:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
@@ -13928,7 +14330,6 @@ packages:
     dependencies:
       '@types/react': 17.0.52
       react: 17.0.2
-    dev: false
 
   /use-latest/1.2.1_q5o373oqrklnndq2vhekyuzhxi:
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
@@ -13942,7 +14343,6 @@ packages:
       '@types/react': 17.0.52
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.2_q5o373oqrklnndq2vhekyuzhxi
-    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -13961,7 +14361,6 @@ packages:
   /uuid/7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
-    dev: false
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -13976,7 +14375,6 @@ packages:
       diff: 5.1.0
       kleur: 4.1.5
       sade: 1.8.1
-    dev: false
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -14029,7 +14427,6 @@ packages:
     dependencies:
       '@types/unist': 2.0.6
       unist-util-stringify-position: 3.0.2
-    dev: false
 
   /vfile/4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
@@ -14046,7 +14443,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.2
       vfile-message: 3.1.2
-    dev: false
 
   /vite/2.9.14:
     resolution: {integrity: sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==}
@@ -14172,7 +14568,6 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
 
   /webpack-bundle-analyzer/4.5.0:
     resolution: {integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==}
@@ -14492,7 +14887,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -14556,7 +14950,6 @@ packages:
 
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-    dev: false
 
   /wordwrapjs/4.0.1:
     resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
@@ -14564,7 +14957,6 @@ packages:
     dependencies:
       reduce-flatten: 2.0.0
       typical: 5.2.0
-    dev: false
 
   /wrap-ansi/6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -14730,4 +15122,3 @@ packages:
 
   /zwitch/2.0.2:
     resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
-    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
       '@docusaurus/plugin-content-pages': ^2.3.0
       '@docusaurus/preset-classic': ^2.3.0
       '@ice/jsx-runtime': ^0.2.0
-      '@ice/pkg': ^1.5.0-beta.0
+      '@ice/pkg': ^1.5.0-beta.1
       '@mdx-js/react': ^1.6.22
       '@swc/helpers': ^0.4.3
       '@types/react': ^17.0.0
@@ -322,7 +322,7 @@ importers:
 
   packages/plugin-jsx-plus:
     specifiers:
-      '@ice/pkg': ^1.4.1
+      '@ice/pkg': ^1.5.0-beta.1
       babel-plugin-transform-jsx-class: ^0.1.3
       babel-plugin-transform-jsx-condition: ^0.1.2
       babel-plugin-transform-jsx-fragment: ^0.1.4
@@ -337,7 +337,7 @@ importers:
       babel-plugin-transform-jsx-memo: 0.1.4
       babel-plugin-transform-jsx-slot: 0.1.2
     devDependencies:
-      '@ice/pkg': 1.4.1
+      '@ice/pkg': link:../pkg
 
   packages/plugin-rax-component:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,7 @@ importers:
 
   examples/react-component:
     specifiers:
+      '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg': workspace:*
       '@ice/pkg-plugin-docusaurus': ^1.4.2
       '@swc/helpers': ^0.4.14
@@ -77,6 +78,7 @@ importers:
       react-dom: ^17.0.0
       style-unit: ^3.0.4
     dependencies:
+      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
       '@swc/helpers': 0.4.14
     devDependencies:
       '@ice/pkg': link:../../packages/pkg
@@ -89,14 +91,19 @@ importers:
 
   examples/react-multi-components:
     specifiers:
+      '@ice/jsx-runtime': ^0.1.1-beta.1
       '@ice/pkg': workspace:*
       '@ice/pkg-plugin-docusaurus': ^1.4.2
+      '@swc/helpers': ^0.4.14
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
       pkg-plugin-example: workspace:*
       react: ^17.0.0
       react-dom: ^17.0.0
       style-unit: ^3.0.4
+    dependencies:
+      '@ice/jsx-runtime': 0.1.1-beta.1_react@17.0.2
+      '@swc/helpers': 0.4.14
     devDependencies:
       '@ice/pkg': link:../../packages/pkg
       '@ice/pkg-plugin-docusaurus': link:../../packages/plugin-docusaurus
@@ -4337,6 +4344,15 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@ice/jsx-runtime/0.1.1-beta.1_react@17.0.2:
+    resolution: {integrity: sha512-AIa7/M5Q0dYU+5Gp3Jsgp3uwFpH7cvMz8P5KxJBIkTZz1t6mDMWK3ASaSZyP6HhreehpCGEpALZ0vSx0CMUj4w==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+    dependencies:
+      react: 17.0.2
+      style-unit: 3.0.5
     dev: false
 
   /@iceworks/eslint-plugin-best-practices/0.2.11_boy655tvqsm6op45de6ax7jimi:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,14 +42,14 @@ importers:
   examples/application:
     specifiers:
       css-loader: ^6.6.0
-      pkg-react-component-example: workspace:*
+      example-pkg-react-component: workspace:*
       react: ^17.0.2
       react-dom: ^17.0.2
       style-loader: ^3.3.1
       webpack: ^5.69.1
       webpack-cli: ^4.9.2
     dependencies:
-      pkg-react-component-example: link:../react-component
+      example-pkg-react-component: link:../react-component
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -101,7 +101,7 @@ importers:
       '@swc/helpers': ^0.4.14
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
-      pkg-plugin-example: workspace:*
+      example-pkg-plugin: workspace:*
       react: ^17.0.0
       react-dom: ^17.0.0
       style-unit: ^3.0.4
@@ -113,7 +113,7 @@ importers:
       '@ice/pkg-plugin-docusaurus': link:../../packages/plugin-docusaurus
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
-      pkg-plugin-example: link:../plugin
+      example-pkg-plugin: link:../plugin
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       style-unit: 3.0.5

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,0 +1,19 @@
+# FAQ
+
+## 为什么需要依赖 `@ice/jsx-runtime`
+
+`@ice/pkg` 在 v1.5.0 版本以后，为支持能在内联样式中使用 rpx 单位，组件需要依赖 `@ice/jsx-runtime` 才能正常渲染。
+
+```jsx
+const Home = () => {
+  return (
+    <div style={{ fontSize: '100rpx' }}>Home</div>
+  )
+}
+```
+
+因此需要将 `@ice/jsx-runtime` 作为项目的 `dependencies`（可执行命令 `npm i @ice/jsx-runtime --save` 安装依赖）。
+
+## 为什么需要依赖 `@swc/helpers`
+
+transform 模式的产物代码中可能依赖一些 helper 函数用以支持目标环境。ICE PKG 默认将这些 helper 函数统一从 `@swc/helpers` 中导出使用，以减小产物代码体积。因此，当你的产物代码中引用了 `@swc/helpers` 时，请务必将 `@swc/helpers` 作为项目的 `dependencies`（可执行命令 `npm i @swc/helpers --save` 安装依赖）。

--- a/website/docs/guide/abilities.md
+++ b/website/docs/guide/abilities.md
@@ -138,7 +138,3 @@ export default defineConfig({
 ## SWC 编译
 
 ICE PKG 采用 SWC 进行 JS 代码的 transform 及 minify。你可以通过自定义插件中的 [`swcCompileOptions`](../plugins-development#swccompileoptions) 来配置 SWC 的编译选项。
-
-:::tip
-transform 模式的产物代码中可能依赖一些 helper 函数用以支持目标环境。ICE PKG 默认将这些 helper 函数统一从 `@swc/helpers` 中导出使用，以减小产物代码体积。因此，当你的产物代码中使用了 `@swc/helpers` 时，请务必将 `@swc/helpers` 加到项目的 dependencies 中并安装之。
-:::

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -44,6 +44,7 @@ const config = {
               },
               { type: 'doc', id: 'guide/config' },
               { type: 'doc', id: 'plugins-development' },
+              { type: 'doc', id: 'faq' },
             ];
           },
           remarkPlugins: [[extractCode, { mobilePreview: false }]],

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     "@algolia/client-search": "^4.9.1",
     "@docusaurus/module-type-aliases": "2.0.1",
     "@docusaurus/theme-common": "^2.2.0",
-    "@ice/pkg-plugin-docusaurus": "workspace:*",
+    "@ice/pkg-plugin-docusaurus": "^1.4.2",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/react": "^17.0.0",
     "typescript": "^4.6.4"

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "@algolia/client-search": "^4.9.1",
     "@docusaurus/module-type-aliases": "2.0.1",
     "@docusaurus/theme-common": "^2.2.0",
+    "@ice/jsx-runtime": "^0.1.1-beta.1",
     "@ice/pkg-plugin-docusaurus": "^1.4.2",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/react": "^17.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     "@algolia/client-search": "^4.9.1",
     "@docusaurus/module-type-aliases": "2.0.1",
     "@docusaurus/theme-common": "^2.2.0",
-    "@ice/pkg-plugin-docusaurus": "^1.2.0",
+    "@ice/pkg-plugin-docusaurus": "workspace:*",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/react": "^17.0.0",
     "typescript": "^4.6.4"

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,6 @@
     "@algolia/client-search": "^4.9.1",
     "@docusaurus/module-type-aliases": "2.0.1",
     "@docusaurus/theme-common": "^2.2.0",
-    "@ice/jsx-runtime": "^0.1.1-beta.1",
     "@ice/pkg-plugin-docusaurus": "^1.4.2",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/react": "^17.0.0",


### PR DESCRIPTION
为支持在组件的内联样式中编写 rpx 单位，需要把 react/jsx-runtime 改成 @ice/jsx-runtime：

```diff
- import { jsx as _jsx } from "react/jsx-runtime";
+ import { jsx as _jsx } from "@ice/jsx-runtime/jsx-runtime";
```

组件项目中需要依赖 @ice/jsx-runtime，对于老项目来说需要增加检测和提示新增 @ice/jsx-runtime 依赖。

模板修改：https://github.com/ice-lab/material-templates/pull/93