### PR TITLE
fix: dependency is not installed

### DIFF
--- a/.changeset/strange-planes-push.md
+++ b/.changeset/strange-planes-push.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: dependency will not be installed

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -25,6 +25,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
+    "@ampproject/remapping": "^2.0.3",
     "@babel/core": "^7.17.5",
     "@babel/parser": "^7.17.3",
     "@rollup/plugin-commonjs": "^21.0.2",
@@ -56,7 +57,6 @@
     "typescript": "^4.9.4"
   },
   "devDependencies": {
-    "@ampproject/remapping": "^2.0.3",
     "@types/babel__core": "^7.1.20",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,7 @@ importers:
       tsc-alias: ^1.8.2
       typescript: ^4.9.4
     dependencies:
+      '@ampproject/remapping': 2.2.0
       '@babel/core': 7.18.6
       '@babel/parser': 7.18.8
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.76.0
@@ -219,7 +220,6 @@ importers:
       tsc-alias: 1.8.2
       typescript: 4.9.4
     devDependencies:
-      '@ampproject/remapping': 2.2.0
       '@types/babel__core': 7.1.20
       '@types/fs-extra': 9.0.13
       '@types/node': 17.0.45


### PR DESCRIPTION
@ampproject/remapping 依赖在 @ice/pkg 安装的时候没有被安装，导致依赖缺失。

https://github.com/ice-lab/icepkg/blob/a2baa8cd70a6d9b7d35ddfdc62bebe27d7b0fcf0/packages/pkg/src/utils.ts#L17