### PR TITLE
fix: can not resolve @docusaurus/plugin-contents-page

### DIFF
--- a/.changeset/mean-feet-melt.md
+++ b/.changeset/mean-feet-melt.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: can not resolve docusaurus/plugin-contents-page

--- a/examples/application/index.js
+++ b/examples/application/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from 'pkg-react-component-example';
+import App from 'example-pkg-react-component';
 
 ReactDOM.render(React.createElement(App, null, 'one'), document.getElementById('ice-container'));

--- a/examples/react-component/README.md
+++ b/examples/react-component/README.md
@@ -1,15 +1,15 @@
-# pkg-react-component-example
+# example-pkg-react-component
 
 组件功能描述
 
 ## Install
 
 ```bash
-$ npm i pkg-react-component-example --save
+$ npm i example-pkg-react-component --save
 ```
 
 ## Usage
 
 ```jsx
-import PkgReactComponentExample from 'pkg-react-component-example';
+import PkgReactComponentExample from 'example-pkg-react-component';
 ```

--- a/examples/react-component/docs/usage.md
+++ b/examples/react-component/docs/usage.md
@@ -5,7 +5,7 @@ sidebar_label: 用法
 本 Demo 演示一行文字的用法。
 
 ```jsx preview
-import Component from 'pkg-react-component-example';
+import Component from 'example-pkg-react-component';
 
 export default function App () {
   return (

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -29,6 +29,10 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
     paths: [__dirname, rootDir],
   });
 
+  const docusaurusPluginContentPagesPath = require.resolve('@docusaurus/plugin-content-pages', {
+    paths: [__dirname, rootDir],
+  });
+
   const sidebarItemsGenerator = params?.sidebarItemsGenerator
     ? params?.sidebarItemsGenerator.toString()
     : false;
@@ -52,6 +56,7 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
     prismReactRendererPath,
     sassDocusaurusPluginPath,
     lessDocusaurusPluginPath,
+    docusaurusPluginContentPagesPath,
   });
 
   const configuredPlugins = params?.configuredPlugins;

--- a/packages/plugin-docusaurus/src/template/docusaurus.hbs
+++ b/packages/plugin-docusaurus/src/template/docusaurus.hbs
@@ -33,7 +33,7 @@ const config = {
     ],
     require.resolve('@ice/pkg-plugin-docusaurus/plugin.js'),
     [
-      require.resolve('@docusaurus/plugin-content-pages'),
+      '{{docusaurusPluginContentPagesPath}}',
       {
         path: '{{pagePath}}',
         routeBasePath: '{{pageRouteBasePath}}',


### PR DESCRIPTION
使用 npm 安装依赖的时候，会出现无法 resolve @docusaurus/plugin-contents-page 的问题