### PR TITLE
chore: remove dist cli option

### DIFF
--- a/.changeset/wise-flowers-learn.md
+++ b/.changeset/wise-flowers-learn.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+chore: remove dist cli option

--- a/packages/pkg/src/config/cliOptions.ts
+++ b/packages/pkg/src/config/cliOptions.ts
@@ -10,11 +10,6 @@ function getCliOptions() {
         return mergeValueToTaskConfig(config, 'analyzer', analyzer);
       },
     },
-    {
-      name: 'dist',
-      commands: ['start'],
-      // TODO: should set it to taskConfig
-    },
   ];
   return cliOptions;
 }


### PR DESCRIPTION
没有任何地方有消费到 --dist，估计是为了watch bundle 产物的，和 build-plugin-component 一样https://www.npmjs.com/package/build-plugin-component