### PR TITLE
chore: add ICE_PKG_BUNDLE_OUTPUT_DIR to process.env

### DIFF
--- a/.changeset/plenty-crews-rescue.md
+++ b/.changeset/plenty-crews-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+chore: add ICE_PKG_BUNDLE_OUTPUT_DIR to process.env for CI

--- a/packages/pkg/src/config/userConfig.ts
+++ b/packages/pkg/src/config/userConfig.ts
@@ -94,6 +94,8 @@ function getUserConfig() {
             bundleConfig,
             { arrayMerge: (destinationArray, sourceArray) => sourceArray },
           );
+          // Set outputDir to process.env for CI
+          process.env.ICE_PKG_BUNDLE_OUTPUT_DIR = mergedConfig.outputDir;
           // Compatible with `bundle.development` config
           if (mergedConfig.development && !mergedConfig.modes.includes('development')) {
             delete mergedConfig.development;


### PR DESCRIPTION
目前供内部 builder 构建的时候消费此变量