### PR TITLE
fix: jsx-plus plugin option

### DIFF
--- a/packages/plugin-jsx-plus/src/index.ts
+++ b/packages/plugin-jsx-plus/src/index.ts
@@ -8,7 +8,7 @@ const defaultPluginOptions: PluginOptions = {
   moduleName: 'react',
 };
 
-const plugin: Plugin = (api, rawOptions: PluginOptions) => {
+const plugin: Plugin = (api, rawOptions: PluginOptions = {}) => {
   const { onGetConfig } = api;
   const pluginOptions = Object.assign(rawOptions, defaultPluginOptions);
   const babelPlugins = [

--- a/packages/plugin-jsx-plus/src/index.ts
+++ b/packages/plugin-jsx-plus/src/index.ts
@@ -8,9 +8,9 @@ const defaultPluginOptions: PluginOptions = {
   moduleName: 'react',
 };
 
-const plugin: Plugin = (api, rawOptions: PluginOptions = {}) => {
+const plugin: Plugin = (api, rawOptions?: PluginOptions) => {
   const { onGetConfig } = api;
-  const pluginOptions = Object.assign(rawOptions, defaultPluginOptions);
+  const pluginOptions = Object.assign({}, defaultPluginOptions, rawOptions);
   const babelPlugins = [
     'babel-plugin-transform-jsx-list',
     'babel-plugin-transform-jsx-condition',


### PR DESCRIPTION
缺少默认值情况下，可能在没有传入插件选项的时候直接报错