### PR TITLE
chore: remove eslint config files

### DIFF
--- a/examples/rax-component/.eslintrc.js
+++ b/examples/rax-component/.eslintrc.js
@@ -1,3 +1,0 @@
-const { getESLintConfig } = require('@iceworks/spec');
-
-module.exports = getESLintConfig('rax-ts');

--- a/packages/pkg/.eslintignore
+++ b/packages/pkg/.eslintignore
@@ -1,3 +1,0 @@
-lib
-node_modules
-__tests__

--- a/packages/pkg/.eslintrc.mjs
+++ b/packages/pkg/.eslintrc.mjs
@@ -1,4 +1,0 @@
-
-module.exports = {
-  extends: '../../.eslintrc.js',
-};

--- a/packages/plugin-docusaurus/.eslintignore
+++ b/packages/plugin-docusaurus/.eslintignore
@@ -1,5 +1,0 @@
-lib
-node_modules
-__tests__
-esm
-es2017

--- a/packages/plugin-docusaurus/.eslintrc.cjs
+++ b/packages/plugin-docusaurus/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: '../../.eslintrc.js',
-};

--- a/packages/plugin-rax-component/.eslintignore
+++ b/packages/plugin-rax-component/.eslintignore
@@ -1,3 +1,0 @@
-lib
-node_modules
-__tests__

--- a/packages/plugin-rax-component/.eslintrc.mjs
+++ b/packages/plugin-rax-component/.eslintrc.mjs
@@ -1,4 +1,0 @@
-
-module.exports = {
-  extends: '../../.eslintrc.js',
-};

--- a/website/docs/guide/abilities.md
+++ b/website/docs/guide/abilities.md
@@ -102,7 +102,6 @@ export default function Home() {
     <div className="container"></div>
   )
 }
-<<<<<<< HEAD
 ```
 
 </TabItem>
@@ -130,25 +129,6 @@ npm add -D sass
 # .less
 npm add -D less
 ```
-=======
-```
-
-</TabItem>
-<TabItem value="index.css" label="src/index.css">
-
-```css
-.container {
-  color: red;
-}
-```
-
-</TabItem>
-</Tabs>
-
-### 预处理器
-
-ICE PKG 内置支持 `.scss`、`.less`、`.sass` 文件，使用方式与 `.css` 文件保持一致。
->>>>>>> main
 
 ### CSS Modules
 
@@ -267,15 +247,9 @@ export default defineConfig({
 ICE PKG 默认为 TypeScript 生成类型文件，**无需主动开启**。
 
 对于一些用户可能使用 [JSDoc](https://jsdoc.app/) 为 JavaScript 生成注解，你可以主动开启为 JavaScript 代码生成类型文件的能力。
-<<<<<<< HEAD
 
 比如，函数 `add` 通过 **JSDoc** 进行类型注解：
 
-=======
-
-比如，函数 `add` 通过 **JSDoc** 进行类型注解：
-
->>>>>>> main
 ```js
 /**
  *


### PR DESCRIPTION
- .eslintrc.mjs 是不生效的，故移除
- monorepo 里统一使用最外层的 .eslintrc.js 即可