### PR TITLE
fix: lose create element module in rax component

### DIFF
--- a/.changeset/shiny-wasps-reply.md
+++ b/.changeset/shiny-wasps-reply.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: lose createElement module in rax component

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -6,7 +6,7 @@ import type { ParserPlugin } from '@babel/parser';
 import { Plugin } from 'rollup';
 import { scriptsFilter } from '../utils.js';
 
-const getParserPlugins = (isTs?: boolean): ParserPlugin[] => {
+const getParserPlugins = (isTS?: boolean): ParserPlugin[] => {
   const commonPlugins: ParserPlugin[] = [
     'jsx',
     'importMeta',
@@ -15,7 +15,7 @@ const getParserPlugins = (isTs?: boolean): ParserPlugin[] => {
     'classPrivateMethods',
   ];
 
-  if (isTs) {
+  if (isTS) {
     return [
       ...commonPlugins,
       'typescript',
@@ -59,12 +59,23 @@ const babelPlugin = (plugins: babel.PluginItem[], options: BabelPluginOptions): 
         },
         plugins,
         presets: [
-          ['@babel/preset-typescript'],
-          ['@babel/preset-react', {
-            pragma,
-            pragmaFrag,
-            throwIfNamespace: false,
-          }],
+          [
+            '@babel/preset-typescript',
+            {
+              isTSX: /\.tsx?$/.test(id),
+              allExtensions: true,
+              jsxPragma: pragma,
+              jsxPragmaFrag: pragmaFrag,
+            },
+          ],
+          [
+            '@babel/preset-react',
+            {
+              pragma,
+              pragmaFrag,
+              throwIfNamespace: false,
+            },
+          ],
         ],
         sourceFileName: id,
       });


### PR DESCRIPTION
### 问题

如果使用 babel 编译 TSX 代码，会把顶层的 `import { createElement } from 'rax';` 给移除掉。

### 解决方案

需要指定指定 `jsxPragma` 和 `jsxPragmaFrag` 告诉 @babel/plugin-transform-typescript 不要移除掉这两个模块导入
 https://babeljs.io/docs/babel-plugin-transform-typescript#jsxpragma
 https://babeljs.io/docs/babel-plugin-transform-typescript#jsxpragmafrag