### PR TITLE
fix: sass-loader and less-loader can't be resolved

### DIFF
--- a/.changeset/few-lamps-remember.md
+++ b/.changeset/few-lamps-remember.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: sass-loader and less-loader can't be resolved

--- a/examples/react-component/pages/index.less
+++ b/examples/react-component/pages/index.less
@@ -1,0 +1,3 @@
+.container {
+  color: blue;
+}

--- a/examples/react-component/pages/index.tsx
+++ b/examples/react-component/pages/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import './index.less';
 
 export default function () {
   return (
-    <div>Index</div>
+    <div className="container">Index</div>
   );
 }

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -45,8 +45,6 @@
     "copy-text-to-clipboard": "^3.0.1",
     "detect-port": "^1.3.0",
     "directory-tree": "^3.3.1",
-    "docusaurus-plugin-less": "^2.0.2",
-    "docusaurus-plugin-sass": "^0.2.2",
     "es-module-lexer": "^0.10.0",
     "fs-extra": "^10.0.0",
     "handlebars": "^4.7.7",

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -21,14 +21,6 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
     paths: [__dirname, rootDir],
   });
 
-  const sassDocusaurusPluginPath = require.resolve('docusaurus-plugin-sass', {
-    paths: [__dirname, rootDir],
-  });
-
-  const lessDocusaurusPluginPath = require.resolve('docusaurus-plugin-less', {
-    paths: [__dirname, rootDir],
-  });
-
   const docusaurusPluginContentPagesPath = require.resolve('@docusaurus/plugin-content-pages', {
     paths: [__dirname, rootDir],
   });
@@ -54,8 +46,6 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
     haveStaticFiles,
     mobilePreview,
     prismReactRendererPath,
-    sassDocusaurusPluginPath,
-    lessDocusaurusPluginPath,
     docusaurusPluginContentPagesPath,
   });
 
@@ -125,4 +115,3 @@ module.exports = {
     path.join(output, 'hijackCreateElement.js'), hijackCreateElementModuleContent, 'utf-8',
   );
 }
-

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -15,7 +15,6 @@ const raxAliasMap = {
 
 module.exports = function (context) {
   const { siteDir } = context;
-  const pkgMeta = require(path.resolve(siteDir, 'package.json'));
 
   const requireOptions = { paths: [siteDir, __dirname] };
 
@@ -40,8 +39,11 @@ module.exports = function (context) {
   };
 
   return {
-    name: 'docusaurus-plugin',
-    configureWebpack(config) {
+    name: 'icepkg:docusaurus-plugin',
+    configureWebpack(config, isServer, utils) {
+      const { getStyleLoaders } = utils;
+      const isProd = process.env.NODE_ENV === 'production';
+
       const cssRules = config.module.rules.filter((rule) => {
         const testRegExpStr = rule.test.toString();
         // eslint-disable-no-useless-escape
@@ -86,6 +88,87 @@ module.exports = function (context) {
             Fragment: ['react', 'Fragment'],
           }),
         ],
+        module: {
+          rules: [
+            // Fork from https://github.com/rlamana/docusaurus-plugin-sass/blob/master/docusaurus-plugin-sass.js
+            // Use `require.resolve()` to resolve the sass-loader because it can not be resolved in ICE PKG project.
+            {
+              test: /\.s[ca]ss$/,
+              oneOf: [
+                {
+                  test: /\.module\.s[ca]ss$/,
+                  use: [
+                    ...getStyleLoaders(isServer, {
+                      modules: {
+                        localIdentName: isProd
+                          ? '[local]_[hash:base64:4]'
+                          : '[local]_[path][name]',
+                        exportOnlyLocals: isServer,
+                      },
+                      importLoaders: 2,
+                      sourceMap: !isProd,
+                    }), {
+                      loader: require.resolve('sass-loader'),
+                    },
+                  ],
+                },
+                {
+                  use: [
+                    ...getStyleLoaders(isServer), {
+                      loader: require.resolve('sass-loader'),
+                    },
+                  ],
+                },
+              ],
+            },
+            // Fork from https://github.com/nonoroazoro/docusaurus-plugin-less/blob/master/index.js
+            // Use `require.resolve()` to resolve the less-loader because it can not be resolved in ICE PKG project.
+            {
+              test: /\.less$/,
+              oneOf: [
+                {
+                  test: /\.module\.less$/,
+                  use: [
+                    ...getStyleLoaders(
+                      isServer,
+                      {
+                        modules: {
+                          localIdentName: isProd
+                            ? '[sha1:hash:hex:5]'
+                            : '[name]_[local]',
+                          exportOnlyLocals: isServer,
+                        },
+                        importLoaders: 1,
+                        sourceMap: !isProd,
+                      },
+                    ),
+                    {
+                      loader: require.resolve('less-loader'),
+                      options: {
+                        lessOptions: {
+                          javascriptEnabled: true,
+                        },
+                      },
+                    },
+                  ],
+                },
+                {
+                  use: [
+                    ...getStyleLoaders(isServer),
+                    {
+                      loader: require.resolve('less-loader'),
+                      options: {
+                        lessOptions: {
+                          javascriptEnabled: true,
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       };
     },
   };

--- a/packages/plugin-docusaurus/src/template/docusaurus.hbs
+++ b/packages/plugin-docusaurus/src/template/docusaurus.hbs
@@ -22,15 +22,6 @@ const config = {
 {{/unless}}
 
   plugins: [
-    '{{sassDocusaurusPluginPath}}',
-    [
-      '{{lessDocusaurusPluginPath}}', 
-      { 
-        lessOptions: {
-          javascriptEnabled: true,
-        }
-      }
-    ],
     require.resolve('@ice/pkg-plugin-docusaurus/plugin.js'),
     [
       '{{docusaurusPluginContentPagesPath}}',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,8 +340,6 @@ importers:
       copy-text-to-clipboard: ^3.0.1
       detect-port: ^1.3.0
       directory-tree: ^3.3.1
-      docusaurus-plugin-less: ^2.0.2
-      docusaurus-plugin-sass: ^0.2.2
       es-module-lexer: ^0.10.0
       fs-extra: ^10.0.0
       handlebars: ^4.7.7
@@ -375,8 +373,6 @@ importers:
       copy-text-to-clipboard: 3.0.1
       detect-port: 1.3.0
       directory-tree: 3.3.1
-      docusaurus-plugin-less: 2.0.2_ufmo642ts42rvy7eqlquam4g74
-      docusaurus-plugin-sass: 0.2.2_xg4lxqntztmmcknhshd3uvfhb4
       es-module-lexer: 0.10.5
       fs-extra: 10.1.0
       handlebars: 4.7.7
@@ -9066,33 +9062,6 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /docusaurus-plugin-less/2.0.2_ufmo642ts42rvy7eqlquam4g74:
-    resolution: {integrity: sha512-ez6WSSvGS8HoJslYHeG5SflyShWvHFXeTTHXPBd3H1T3zgq9wp6wD7scXm+rXyyfhFhP5VNiIqhYB78z4OLjwg==}
-    peerDependencies:
-      '@docusaurus/core': '>=2.0.0-beta.9'
-      less: '>=4.0.0'
-      less-loader: '>=10.0.0'
-    dependencies:
-      '@docusaurus/core': 2.3.0_lb6du3saekb5anf2gjv3wxj3oq
-      less: 4.1.3
-      less-loader: 11.0.0_less@4.1.3+webpack@5.75.0
-    dev: false
-
-  /docusaurus-plugin-sass/0.2.2_xg4lxqntztmmcknhshd3uvfhb4:
-    resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
-    peerDependencies:
-      '@docusaurus/core': ^2.0.0-beta
-      sass: ^1.30.0
-    dependencies:
-      '@docusaurus/core': 2.3.0_lb6du3saekb5anf2gjv3wxj3oq
-      sass: 1.53.0
-      sass-loader: 10.3.1_sass@1.53.0+webpack@5.75.0
-    transitivePeerDependencies:
-      - fibers
-      - node-sass
-      - webpack
-    dev: false
-
   /dom-accessibility-api/0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
@@ -16463,31 +16432,6 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  /sass-loader/10.3.1_sass@1.53.0+webpack@5.75.0:
-    resolution: {integrity: sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-      sass: ^1.3.0
-      webpack: ^4.36.0 || ^5.0.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      klona: 2.0.5
-      loader-utils: 2.0.2
-      neo-async: 2.6.2
-      sass: 1.53.0
-      schema-utils: 3.1.1
-      semver: 7.3.7
-      webpack: 5.75.0
-    dev: false
 
   /sass-loader/12.6.0_sass@1.53.0+webpack@5.75.0:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -31,12 +31,4 @@ $ npm i @swc/helpers --save
 
 ## `Error: Can't resolve 'sass-loader' in ...`
 
-出现这个报错的原因是在使用 docusaurus 插件时，docusaurus 无法正常 resolve 到 `sass-loader` 依赖。解决方案是暂时先安装一下依赖：
-
-```bash
-# 使用 scss
-$ npm i sass-loader -D
-
-# 使用 less
-$ npm i less-loader -D
-```
+出现这个报错的原因是在使用 docusaurus 插件时，docusaurus 无法正常 resolve 到 `sass-loader` 依赖。请更新 `@ice/pkg-plugin-docusaurus` 到最新版本。


### PR DESCRIPTION
### 背景

@ice/pkg-plugin-docusaurus 使用社区的 npm 包 `docusaurus-plugin-less` 和 `docusaurus-plugin-sass` 分别解析 less 和 sass。但我们使用子进程启动 docusaurus 本地预览服务，并且指定了 cwd 是 rootDir：
https://github.com/ice-lab/icepkg/blob/bca916d4093eda6f21995f8cea514fec100bbcc4/packages/plugin-docusaurus/src/doc.mts#L41
导致对于以下代码在 require `sass-loader` 的时候没法 resolve 到（因为是从项目根目录 node_modules 开始向上目录开始找）
https://github.com/rlamana/docusaurus-plugin-sass/blob/d97f88c3e24fd16477eac6d8f56a2703425ece9a/docusaurus-plugin-sass.js#L31
然后会报这样的错误：
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/44047106/226272121-89f372cb-fea7-4ee0-a6fa-1e42da9f989f.png">

虽然已经提了 PR，但一直没有发版本：
https://github.com/rlamana/docusaurus-plugin-sass/pull/25

因此考虑把 sass 和 less 的 webpack 解析规则内置到 docusaurus 插件