### PR TITLE
fix: some es2017 syntaxs are not compatible with sarafi 10.1

### DIFF
--- a/.changeset/violet-lobsters-behave.md
+++ b/.changeset/violet-lobsters-behave.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: some es2017 syntax is not compatible with safari 10.1

--- a/packages/pkg/src/helpers/defaultSwcConfig.ts
+++ b/packages/pkg/src/helpers/defaultSwcConfig.ts
@@ -19,7 +19,7 @@ export const getDefaultBundleSwcConfig = (
   const browserTargets = taskName === TaskName.BUNDLE_ES2017 ? {
     // https://github.com/ice-lab/ice-next/issues/54#issuecomment-1083263523
     chrome: 61,
-    safari: 10.1,
+    safari: 11,
     firefox: 60,
     edge: 16,
     ios: 11,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44047106/226797749-41109daa-a5a6-45ba-8d9e-1ec60a90a7b4.png)
