### PR TITLE
fix: can not render two components in one mdx file

### DIFF
--- a/.changeset/lemon-keys-turn.md
+++ b/.changeset/lemon-keys-turn.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: can not render two components in one mdx file

--- a/examples/react-component/docs/usage.md
+++ b/examples/react-component/docs/usage.md
@@ -13,3 +13,16 @@ export default function App () {
   )
 }
 ```
+
+```jsx preview
+import Component from 'example-pkg-react-component';
+
+export default function App () {
+  return (
+    <>
+      <h1>I am Component</h1>
+      <Component />
+    </>
+  )
+}
+```

--- a/packages/plugin-docusaurus/src/Previewer/index.tsx
+++ b/packages/plugin-docusaurus/src/Previewer/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PcPreview from './PC';
+import PCPreview from './PC';
 import MobilePreview from './Mobile';
 
 interface PreviewerProps {
@@ -22,9 +22,9 @@ const Previewer: React.FunctionComponent<React.PropsWithChildren<PreviewerProps>
     return <MobilePreview code={deserializedCode} url={url} />;
   } else {
     return (
-      <PcPreview code={deserializedCode}>
+      <PCPreview code={deserializedCode}>
         {children}
-      </PcPreview>
+      </PCPreview>
     );
   }
 };

--- a/packages/plugin-docusaurus/src/genDemoPages/extractCodePlugin.mts
+++ b/packages/plugin-docusaurus/src/genDemoPages/extractCodePlugin.mts
@@ -17,9 +17,16 @@ export default function getExtractCodePlugin(filepath: string, rootDir: string) 
         if (node.meta === 'preview') {
           const { lang } = node;
           checkCodeLang(lang);
-          const { demoFilename, demoFilepath } = getDemoFileInfo({ rootDir, filepath, lang });
+          const { demoFilename, demoFilepath } = getDemoFileInfo({ rootDir, code: node.value, lang });
           const { pageFilename, pageFileCode } = getPageFileInfo({ rootDir, demoFilepath, demoFilename });
-          genDemoPages({ filepath, code: node.value, demoFilename, demoFilepath, pageFilename, pageFileCode });
+          genDemoPages({
+            filepath,
+            code: node.value,
+            demoFilename,
+            demoFilepath,
+            pageFilename,
+            pageFileCode,
+          });
         }
       });
     };

--- a/packages/plugin-docusaurus/src/remark/extractCode.js
+++ b/packages/plugin-docusaurus/src/remark/extractCode.js
@@ -30,6 +30,7 @@ const extractCodePlugin = (options) => {
           rootDir,
           filepath: vfile.path,
           lang,
+          code: node.value,
         });
         const { pageFilename, pageFileCode } = getPageFileInfo({
           rootDir,
@@ -79,7 +80,7 @@ const extractCodePlugin = (options) => {
         value: `import Previewer from '${previewerComponentPath}';`,
       });
 
-      // Import <Browser /> ahead.
+      // Import <BrowserOnly /> ahead.
       ast.children.unshift({
         type: 'import',
         value: "import BrowserOnly from '@docusaurus/BrowserOnly';",

--- a/packages/plugin-docusaurus/src/remark/getFileInfo.js
+++ b/packages/plugin-docusaurus/src/remark/getFileInfo.js
@@ -4,10 +4,10 @@ const uniqueFilename = require('./uniqueFilename.js');
 
 const DOCUSAURUS_DIR = '.docusaurus';
 
-const getDemoFileInfo = ({ rootDir, filepath, lang }) => {
+const getDemoFileInfo = ({ rootDir, code, lang }) => {
   const demoDir = path.join(rootDir, DOCUSAURUS_DIR, 'demos');
   fse.ensureDirSync(demoDir);
-  const demoFilename = uniqueFilename(filepath);
+  const demoFilename = uniqueFilename(code);
   const demoFilepath = path.join(demoDir, `${demoFilename}.${lang}`);
   return { demoFilename, demoFilepath };
 };

--- a/packages/plugin-docusaurus/src/remark/uniqueFilename.js
+++ b/packages/plugin-docusaurus/src/remark/uniqueFilename.js
@@ -3,9 +3,9 @@ const { createHash } = require('crypto');
 const DEMO_PREFIX = 'IcePkgDemo';
 
 /** Use the md5 value of docPath */
-const uniqueFilename = (originalDocPath) => {
+const uniqueFilename = (code) => {
   const hash = createHash('md5');
-  hash.update(originalDocPath);
+  hash.update(code);
   const hashValue = hash.digest('hex');
 
   return `${DEMO_PREFIX}_${hashValue.slice(0, 6)}`;


### PR DESCRIPTION
假设在 mdx 文件里有以下的内容，理论上能正常分别显示 XYZ 和 ABC：
<img width="406" alt="image" src="https://user-images.githubusercontent.com/44047106/227109086-969f0f46-01e6-4664-8282-432ce830e0f5.png">
但结果却是：
<img width="473" alt="image" src="https://user-images.githubusercontent.com/44047106/227109327-ff22c281-c416-40bf-8ad4-1d6a6f148776.png">
