### PR TITLE
feat: support modify swc compile options

### DIFF
--- a/.changeset/curly-cheetahs-hear.md
+++ b/.changeset/curly-cheetahs-hear.md
@@ -3,3 +3,4 @@
 ---
 
 feat: support modify swc compile options
+feat: enable `externalHelpers` config by default

--- a/.changeset/curly-cheetahs-hear.md
+++ b/.changeset/curly-cheetahs-hear.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+feat: support modify swc compile options

--- a/.changeset/gorgeous-frogs-repair.md
+++ b/.changeset/gorgeous-frogs-repair.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-rax-component': patch
+---
+
+chore: use Plugin type instead of deprecated PkgPlugin type

--- a/examples/plugin/src/index.ts
+++ b/examples/plugin/src/index.ts
@@ -28,6 +28,9 @@ const plugin: Plugin = (api) => {
     config.modifyStylesOptions.push((options) => {
       return options;
     });
+    config.modifySwcCompileOptions = (originOptions) => {
+      return originOptions;
+    };
   };
 
   onGetConfig(TaskName.BUNDLE_ES2017, bundleTaskCallback);

--- a/examples/plugin/tsconfig.json
+++ b/examples/plugin/tsconfig.json
@@ -5,6 +5,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "lib": ["ESNext"],
+    "outDir": "lib",
     "skipLibCheck": true
   },
   "include": ["src"],

--- a/examples/react-multi-components/build.config.mts
+++ b/examples/react-multi-components/build.config.mts
@@ -4,7 +4,7 @@ import { defineConfig } from '@ice/pkg';
 export default defineConfig({
   plugins: [
     ['@ice/pkg-plugin-docusaurus', { /* outputDir: './docusaurus-build', */ }],
-    'pkg-plugin-example',
+    'example-pkg-plugin',
   ],
   transform: {
     formats: ['esm', 'es2017'],

--- a/packages/pkg/src/helpers/defaultSwcConfig.ts
+++ b/packages/pkg/src/helpers/defaultSwcConfig.ts
@@ -33,6 +33,7 @@ export const getDefaultBundleSwcConfig = (
       target,
       baseUrl: ctx.rootDir,
       paths: formatAliasToTSPathsConfig(bundleTaskConfig.alias),
+      externalHelpers: true,
     },
     minify: false,
     // Always generate map in bundle mode,
@@ -42,7 +43,7 @@ export const getDefaultBundleSwcConfig = (
     env: {
       targets: browserTargets,
       mode: 'usage',
-      coreJs: '3',
+      coreJs: '3.29',
     },
   };
 };

--- a/packages/pkg/src/helpers/getBuildTasks.ts
+++ b/packages/pkg/src/helpers/getBuildTasks.ts
@@ -29,18 +29,24 @@ function getBuildTask(buildTask: BuildTask, context: Context): BuildTask {
   config.sourcemap = config.sourcemap ?? command === 'start';
 
   if (config.type === 'bundle') {
-    config.swcCompileOptions = deepmerge(
-      getDefaultBundleSwcConfig(config, context, taskName),
-      config.swcCompileOptions || {},
-    );
+    const defaultBundleSwcConfig = getDefaultBundleSwcConfig(config, context, taskName);
+    config.swcCompileOptions = typeof config.modifySwcCompileOptions === 'function' ?
+      config.modifySwcCompileOptions(defaultBundleSwcConfig) :
+      deepmerge(
+        defaultBundleSwcConfig,
+        config.swcCompileOptions || {},
+      );
   } else if (config.type === 'transform') {
     config.outputDir = getTransformDefaultOutputDir(rootDir, taskName);
     const mode = command === 'build' ? 'production' : 'development';
     config.modes = [mode];
-    config.swcCompileOptions = deepmerge(
-      getDefaultTransformSwcConfig(config, context, taskName, mode),
-      config.swcCompileOptions || {},
-    );
+    const defaultTransformSwcConfig = getDefaultTransformSwcConfig(config, context, taskName, mode);
+    config.swcCompileOptions = typeof config.modifySwcCompileOptions === 'function' ?
+      config.modifySwcCompileOptions(defaultTransformSwcConfig) :
+      deepmerge(
+        defaultTransformSwcConfig,
+        config.swcCompileOptions || {},
+      );
   } else {
     throw new Error('Invalid task type.');
   }

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -168,9 +168,13 @@ interface _TaskConfig {
   modifyRollupOptions?: Array<(rollupOptions: RollupOptions) => RollupOptions>;
   /**
   * Extra swc compile options
-  * @see https://swc.rs/docs/configuration/compilationv
+  * @see https://swc.rs/docs/configuration/compilation
   */
   swcCompileOptions?: Config;
+  /**
+   * Modify swc compile options
+   */
+  modifySwcCompileOptions?: (swcCompileOptions: Config) => Config;
   /**
    * Extra babel plugins
    */

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -167,12 +167,13 @@ interface _TaskConfig {
    */
   modifyRollupOptions?: Array<(rollupOptions: RollupOptions) => RollupOptions>;
   /**
-  * Extra swc compile options
+  * Configure extra swc compile options.
   * @see https://swc.rs/docs/configuration/compilation
   */
   swcCompileOptions?: Config;
   /**
-   * Modify swc compile options
+   * Modify inner swc compile options.
+   * @see https://swc.rs/docs/configuration/compilation
    */
   modifySwcCompileOptions?: (swcCompileOptions: Config) => Config;
   /**

--- a/packages/plugin-rax-component/src/index.ts
+++ b/packages/plugin-rax-component/src/index.ts
@@ -1,6 +1,6 @@
-import type { PkgPlugin } from '@ice/pkg';
+import type { Plugin } from '@ice/pkg';
 
-const plugin: PkgPlugin = (api) => {
+const plugin: Plugin = (api) => {
   const { onGetConfig } = api;
 
   onGetConfig((config) => {
@@ -18,7 +18,7 @@ const plugin: PkgPlugin = (api) => {
             legacyDecorator: true,
           },
           externalHelpers: true,
-          loose: false, // No recommand
+          loose: false, // No recommend
         },
       },
     };

--- a/website/docs/reference/plugins-development.md
+++ b/website/docs/reference/plugins-development.md
@@ -279,13 +279,31 @@ const plugin = (api) => {
   });
 };
 ```
+#### modifySwcCompileOptions
+
++ 类型：`(config: swc.Config) => swc.Config`
++ 默认值：`undefined`
+
+用于修改 SWC 编译选项，函数入参是内置的 SWC 配置。具体编译选项可参考 [SWC 配置](https://swc.rs/docs/configuration/swcrc)。
+
+```js
+const plugin = (api) => {
+  const { onGetConfig } = api;
+  onGetConfig(config => {
+    config.modifySwcCompileOptions = (originOptions) => {
+      const newOptions = { ...originOptions, env: { } };
+      return newOptions;
+    }
+  });
+};
+```
 
 #### swcCompileOptions
 
 + 类型：`swc.Config`
 + 默认值：`{}`
 
-swc 编译选项，会与默认的选项合并。具体编译选项可参考 [swc 配置](https://swc.rs/docs/configuration/swcrc)。
+设置 SWC 编译选项，会与默认的选项合并。优先级低于 `modifySwcCompileOptions`。具体编译选项可参考 [SWC 配置](https://swc.rs/docs/configuration/swcrc)。
 
 ```js
 const plugin = (api) => {

--- a/website/docs/reference/plugins-development.md
+++ b/website/docs/reference/plugins-development.md
@@ -303,7 +303,11 @@ const plugin = (api) => {
 + 类型：`swc.Config`
 + 默认值：`{}`
 
-设置 SWC 编译选项，会与默认的选项合并。优先级低于 `modifySwcCompileOptions`。具体编译选项可参考 [SWC 配置](https://swc.rs/docs/configuration/swcrc)。
+:::tip
+推荐使用 [modifySwcCompileOptions](#modifyswccompileoptions) 来修改 SWC 编译选项。
+:::
+
+设置 SWC 编译选项，会与内置的选项合并。优先级低于 `modifySwcCompileOptions`。具体编译选项可参考 [SWC 配置](https://swc.rs/docs/configuration/swcrc)。
 
 ```js
 const plugin = (api) => {


### PR DESCRIPTION
支持使用 modifySwcCompileOptions 方法修改默认的 swc 配置：

```js
const plugin = (api) => {
  const { onGetConfig } = api;
  onGetConfig(config => {
    config.modifySwcCompileOptions = (originOptions) => {
      const newOptions = { ...originOptions, env: { } };
      return newOptions;
    }
  });
};
```