### PR TITLE
feat: support `bundle.polyfill` config

### DIFF
--- a/.changeset/unlucky-radios-tease.md
+++ b/.changeset/unlucky-radios-tease.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+feat: add bundle.polyfill config

--- a/packages/pkg/src/config/userConfig.ts
+++ b/packages/pkg/src/config/userConfig.ts
@@ -19,6 +19,7 @@ function getUserConfig() {
       js: (mode: string, command: string) => { return mode === 'production' && command === 'build'; },
       css: (mode: string, command: string) => { return mode === 'production' && command === 'build'; },
     },
+    polyfill: 'usage',
   };
   const defaultTransformUserConfig: TransformUserConfig = {
     formats: ['esm', 'es2017'],

--- a/packages/pkg/src/helpers/defaultSwcConfig.ts
+++ b/packages/pkg/src/helpers/defaultSwcConfig.ts
@@ -10,27 +10,31 @@ import type { Config, ModuleConfig } from '@swc/core';
 import getDefaultDefineValues from './getDefaultDefineValues.js';
 import formatAliasToTSPathsConfig from './formatAliasToTSPathsConfig.js';
 
+// https://github.com/ice-lab/ice-next/issues/54#issuecomment-1083263523
+const LEGACY_BROWSER_TARGETS = {
+  chrome: 49,
+  ie: 11,
+};
+const MODERN_BROWSER_TARGETS = {
+  chrome: 61,
+  safari: 11,
+  firefox: 60,
+  edge: 16,
+  ios: 11,
+};
+
 export const getDefaultBundleSwcConfig = (
   bundleTaskConfig: BundleTaskConfig,
   ctx: Context,
   taskName: TaskValue,
 ): Config => {
-  const target = taskName === TaskName.BUNDLE_ES2017 ? 'es2017' : 'es5';
-  const browserTargets = taskName === TaskName.BUNDLE_ES2017 ? {
-    // https://github.com/ice-lab/ice-next/issues/54#issuecomment-1083263523
-    chrome: 61,
-    safari: 11,
-    firefox: 60,
-    edge: 16,
-    ios: 11,
-  } : {
-    chrome: 49,
-    ie: 11,
+  const browserTargets = taskName === TaskName.BUNDLE_ES2017 ? MODERN_BROWSER_TARGETS : LEGACY_BROWSER_TARGETS;
+  const polyfillConfig = bundleTaskConfig.polyfill === false ? {} : {
+    mode: bundleTaskConfig.polyfill,
+    coreJs: '3.29',
   };
-
   return {
     jsc: {
-      target,
       baseUrl: ctx.rootDir,
       paths: formatAliasToTSPathsConfig(bundleTaskConfig.alias),
       externalHelpers: true,
@@ -42,8 +46,7 @@ export const getDefaultBundleSwcConfig = (
     // 由 env 字段统一处理 syntax & polyfills
     env: {
       targets: browserTargets,
-      mode: 'usage',
-      coreJs: '3.29',
+      ...polyfillConfig,
     },
   };
 };

--- a/packages/pkg/src/helpers/defaultSwcConfig.ts
+++ b/packages/pkg/src/helpers/defaultSwcConfig.ts
@@ -29,10 +29,6 @@ export const getDefaultBundleSwcConfig = (
   taskName: TaskValue,
 ): Config => {
   const browserTargets = taskName === TaskName.BUNDLE_ES2017 ? MODERN_BROWSER_TARGETS : LEGACY_BROWSER_TARGETS;
-  const polyfillConfig = bundleTaskConfig.polyfill === false ? {} : {
-    mode: bundleTaskConfig.polyfill,
-    coreJs: '3.29',
-  };
   return {
     jsc: {
       baseUrl: ctx.rootDir,
@@ -46,7 +42,8 @@ export const getDefaultBundleSwcConfig = (
     // 由 env 字段统一处理 syntax & polyfills
     env: {
       targets: browserTargets,
-      ...polyfillConfig,
+      coreJs: '3.29',
+      mode: bundleTaskConfig.polyfill === false ? undefined : bundleTaskConfig.polyfill,
     },
   };
 };

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -45,7 +45,7 @@ export interface BundleUserConfig {
   name?: string;
   /**
    * Output directory
-   * @default dist
+   * @default 'dist'
    */
   outputDir?: string;
   /**
@@ -82,6 +82,14 @@ export interface BundleUserConfig {
     js?: boolean | ((mode: string, command: string) => JSMinify);
     css?: boolean | ((mode: string, command: string) => CSSMinify);
   };
+
+  /**
+   * Weather or not add the polyfill to the code.
+   * @default ['usage']
+   *
+   * In the next version(v2), the value of polyfill will be `false`.
+   */
+  polyfill?: false | 'entry' | 'usage';
 }
 
 export interface UserConfig {

--- a/website/docs/reference/config.md
+++ b/website/docs/reference/config.md
@@ -428,7 +428,29 @@ export default defineConfig({
   },
 });
 ```
-#### development（已废弃，请使用 modes）
+
+#### polyfill
+
++ 类型：`false | 'entry' | 'usage'`
++ 默认值：`'usage'`
+
+配置处理 polyfill 的逻辑。不同值的含义：
+
+- `false`: 不引入任何 polyfill
+- `'entry'`: 根据配置的 format 值在每个文件开头都引入对应的 polyfill
+- `'usage'`: 根据源码中使用到的代码按需引入 polyfill
+
+:::caution
+`polyfill` 默认值将会在下个大版本改成 `false`。推荐组件的 bundle 产物不引入任何 polyfill（也就是设置成 `false`），而是使用 CDN 的方式引入 polyfill。
+:::
+
+#### development
+
+:::caution
+
+此选项已废弃，请使用 [modes](#modes)
+
+:::
 
 + 类型：`boolean`
 + 默认值：`false`

--- a/website/docs/reference/config.md
+++ b/website/docs/reference/config.md
@@ -441,7 +441,7 @@ export default defineConfig({
 - `'usage'`: 根据源码中使用到的代码按需引入 polyfill
 
 :::caution
-`polyfill` 默认值将会在下个大版本改成 `false`。推荐组件的 bundle 产物不引入任何 polyfill（也就是设置成 `false`），而是使用 CDN 的方式引入 polyfill。
+`polyfill` 默认值将会在下个 BK 版本改成 `false`。推荐组件的 bundle 产物不引入任何 polyfill（也就是设置成 `false`），而是使用 CDN 的方式引入 polyfill。
 :::
 
 #### development


### PR DESCRIPTION
## 背景

在组件层面，组件的产物不应该引入任何 polyfill 的内容，而是由上层应用决定的。现在有一些 bundle 产物体积很大，原因是把 polyfill 也打包进去了，影响了性能。

## 方案

为了解决上面的问题，同时要兼容以前的表现，新增 `bundle.polyfill` 配置。支持配置在 bundle 模式下 polyfill 注入的规则。当前默认值兼容现在的表现，推荐使用 false，并在下一个版本修改为 false