### PR TITLE
fix: show monorepo template when create a sub package

### DIFF
--- a/.changeset/four-beans-hang.md
+++ b/.changeset/four-beans-hang.md
@@ -1,0 +1,5 @@
+---
+'@ice/create-pkg': patch
+---
+
+fix: show monorepo templates when creating a sub package

--- a/packages/create-pkg/src/index.mts
+++ b/packages/create-pkg/src/index.mts
@@ -72,7 +72,7 @@ async function create(dirPath: string, dirname: string, options: CliOptions): Pr
 
   let templateNpmName = options.template;
   if (!templateNpmName) {
-    templateNpmName = await inquireTemplateNpmName();
+    templateNpmName = await inquireTemplateNpmName(options.workspace);
   }
 
   const npmName = options.npmName ?? (templateNpmName.startsWith('@ice/template-pkg-monorepo') ? '' : await inquirePackageName());

--- a/packages/create-pkg/src/inquireTemplateNpmName.ts
+++ b/packages/create-pkg/src/inquireTemplateNpmName.ts
@@ -1,40 +1,46 @@
 import inquirer from 'inquirer';
 import getInfo from './langs/index.js';
 
-export default async function inquireTemplateNpmName() {
+
+export default async function inquireTemplateNpmName(workspace?: boolean) {
   const info = await getInfo();
+  const baseTemplateChoices = [
+    {
+      name: info.reactComponent,
+      value: '@ice/template-pkg-react',
+    },
+    {
+      name: info.nodeModule,
+      value: '@ice/template-pkg-node',
+    },
+    {
+      name: info.webLibrary,
+      value: '@ice/template-pkg-web',
+    },
+    {
+      name: info.raxComponent,
+      value: '@ice/template-pkg-rax',
+    },
+  ];
+  const monorepoTemplateChoices = [
+    {
+      name: info.reactMonorepo,
+      value: '@ice/template-pkg-monorepo-react',
+    },
+    {
+      name: info.nodeMonorepo,
+      value: '@ice/template-pkg-monorepo-node',
+    },
+  ];
+  // If create a sub package(the cli flag is `-w`), don't show the monorepo templates.
+  const choices = baseTemplateChoices.concat(!workspace ? monorepoTemplateChoices : []);
   const { templateNpmName } = await inquirer.prompt([
     {
       type: 'list',
       message: info.selectProjectType,
       name: 'templateNpmName',
       default: '@ice/template-pkg-react',
-      choices: [
-        {
-          name: info.reactComponent,
-          value: '@ice/template-pkg-react',
-        },
-        {
-          name: info.nodeModule,
-          value: '@ice/template-pkg-node',
-        },
-        {
-          name: info.webLibrary,
-          value: '@ice/template-pkg-web',
-        },
-        {
-          name: info.raxComponent,
-          value: '@ice/template-pkg-rax',
-        },
-        {
-          name: info.reactMonorepo,
-          value: '@ice/template-pkg-monorepo-react',
-        },
-        {
-          name: info.nodeMonorepo,
-          value: '@ice/template-pkg-monorepo-node',
-        },
-      ],
+      choices,
     },
   ]);
   return templateNpmName;


### PR DESCRIPTION
指定了 `-w` 参数（以指定创建子项目），不应该显示 monorepo 模板的选项
<img width="607" alt="image" src="https://user-images.githubusercontent.com/44047106/236722533-f2ccdb07-3c74-476c-bcb1-ee9fcac9579a.png">