### PR TITLE
feat: add workspace template option

### DIFF
--- a/.changeset/green-hairs-join.md
+++ b/.changeset/green-hairs-join.md
@@ -1,0 +1,5 @@
+---
+'@ice/create-pkg': patch
+---
+
+feat: add workspace tempalte option

--- a/packages/create-pkg/src/index.mts
+++ b/packages/create-pkg/src/index.mts
@@ -83,6 +83,8 @@ async function create(dirPath: string, dirname: string, options: CliOptions): Pr
     rootDir: dirPath,
     templateOptions: {
       npmName,
+      // @ts-expect-error generateMaterial should support index signature.
+      workspace: options.workspace,
     },
     materialTemplateDir: tempDir,
     materialType: 'component',


### PR DESCRIPTION
创建子项目的时候，不应该增加 docusaurus 插件

Ref: https://github.com/ice-lab/material-templates/pull/99/files