### PR TITLE
fix: tnpm oom

### DIFF
--- a/.changeset/fair-lobsters-grow.md
+++ b/.changeset/fair-lobsters-grow.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: OOM when use tnpm/cnpm to install dependencies

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -167,12 +167,12 @@ module.exports = function (context) {
           }),
         ],
         snapshot: {
-          // tnpm / cnpm 安装时，webpack 5 的持久缓存无法生成，长时间将导致 OOM
-          // 原因：[managedPaths](https://webpack.js.org/configuration/other-options/#managedpaths) 在 tnpm / cnpm 安装的情况下失效，导致持久缓存在处理 node_modules
-          // 通过指定 [immutablePaths](https://webpack.js.org/configuration/other-options/#immutablepaths) 进行兼容
-          // 依赖路径中同时包含包名和版本号即可满足 immutablePaths 的使用
+          // When tnpm/cnpm is installed, the persistent cache of webpack 5 cannot be generated.
+          // Reason：[managedPaths](https://webpack.js.org/configuration/other-options/#managedpaths) Failed in the case of tnpm/cnpm installation, causing persistent cache to handle node_modules.
+          // Specify [immutablePaths](https://webpack.js.org/configuration/other-options/#immutablepaths) to compat it.
+          // immutablePaths can be used with both the package name and version number in the dependent paths
 
-          // 通过安装后的 package.json 中是否包含 __npminstall_done 字段来判断是否为 tnpm / cnpm 安装模式
+          // tnpm/cnpm installation mode is determined by whether the installed package.json contains the __npminstall_done field
           immutablePaths: require('../package.json').__npminstall_done ?
             [path.join(siteDir, 'node_modules')] :
             [],

--- a/packages/plugin-docusaurus/src/plugin.js
+++ b/packages/plugin-docusaurus/src/plugin.js
@@ -166,6 +166,17 @@ module.exports = function (context) {
             Fragment: ['react', 'Fragment'],
           }),
         ],
+        snapshot: {
+          // tnpm / cnpm 安装时，webpack 5 的持久缓存无法生成，长时间将导致 OOM
+          // 原因：[managedPaths](https://webpack.js.org/configuration/other-options/#managedpaths) 在 tnpm / cnpm 安装的情况下失效，导致持久缓存在处理 node_modules
+          // 通过指定 [immutablePaths](https://webpack.js.org/configuration/other-options/#immutablepaths) 进行兼容
+          // 依赖路径中同时包含包名和版本号即可满足 immutablePaths 的使用
+
+          // 通过安装后的 package.json 中是否包含 __npminstall_done 字段来判断是否为 tnpm / cnpm 安装模式
+          immutablePaths: require('../package.json').__npminstall_done ?
+            [path.join(siteDir, 'node_modules')] :
+            [],
+        },
       };
     },
   };


### PR DESCRIPTION
问题：使用 tnpm/cnpm 安装依赖时，当保存代码时，可能会出现内存溢出的问题。

原因是因为 webpack5 的持久缓存无法生成，与 ice.js 3 解决方法一致。