### PR TITLE
feat: support configure compile deps

### DIFF
--- a/.changeset/thick-wombats-look.md
+++ b/.changeset/thick-wombats-look.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+feat: support configure compile deps

--- a/packages/pkg/src/config/userConfig.ts
+++ b/packages/pkg/src/config/userConfig.ts
@@ -20,6 +20,7 @@ function getUserConfig() {
       css: (mode: string, command: string) => { return mode === 'production' && command === 'build'; },
     },
     polyfill: 'usage',
+    compileDependencies: false,
   };
   const defaultTransformUserConfig: TransformUserConfig = {
     formats: ['esm', 'es2017'],

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -52,6 +52,7 @@ export function getRollupOptions(
           pragma: taskConfig?.swcCompileOptions?.jsc?.transform?.react?.pragma,
           pragmaFrag: taskConfig?.swcCompileOptions?.jsc?.transform?.react?.pragmaFrag,
         },
+        taskConfig.type === 'bundle' && taskConfig.compileDependencies,
       ),
     );
   }
@@ -60,6 +61,7 @@ export function getRollupOptions(
       taskConfig.jsxRuntime,
       rootDir,
       taskConfig.swcCompileOptions,
+      taskConfig.type === 'bundle' && taskConfig.compileDependencies,
     ),
   );
 

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -4,7 +4,8 @@
 import * as babel from '@babel/core';
 import type { ParserPlugin } from '@babel/parser';
 import { Plugin } from 'rollup';
-import { scriptsFilter } from '../utils.js';
+import { createScriptsFilter } from '../utils.js';
+import type { BundleTaskConfig } from '../types.js';
 
 const getParserPlugins = (isTS?: boolean): ParserPlugin[] => {
   const commonPlugins: ParserPlugin[] = [
@@ -30,12 +31,17 @@ interface BabelPluginOptions {
   pragmaFrag?: string;
 }
 
-const babelPlugin = (plugins: babel.PluginItem[], options: BabelPluginOptions): Plugin => {
+const babelPlugin = (
+  plugins: babel.PluginItem[],
+  options: BabelPluginOptions,
+  compileDependencies?: BundleTaskConfig['compileDependencies'],
+): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const {
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
   } = options;
+  const scriptsFilter = createScriptsFilter(compileDependencies);
   return {
     name: 'ice-pkg:babel',
 

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -2,10 +2,10 @@ import { extname, basename, relative, sep } from 'path';
 import * as swc from '@swc/core';
 import deepmerge from 'deepmerge';
 import { isTypescriptOnly } from '../helpers/suffix.js';
-import { checkDependencyExists, scriptsFilter } from '../utils.js';
+import { checkDependencyExists, createScriptsFilter } from '../utils.js';
 
 import type { Options as swcCompileOptions, Config, TsParserConfig, EsParserConfig } from '@swc/core';
-import type { TaskConfig, OutputFile } from '../types.js';
+import type { TaskConfig, OutputFile, BundleTaskConfig } from '../types.js';
 import type { Plugin } from 'rollup';
 
 const JSX_RUNTIME_SOURCE = '@ice/jsx-runtime';
@@ -63,7 +63,9 @@ const swcPlugin = (
   jsxRuntime: TaskConfig['jsxRuntime'],
   rootDir: string,
   extraSwcOptions?: Config,
+  compileDependencies?: BundleTaskConfig['compileDependencies'],
 ): Plugin => {
+  const scriptsFilter = createScriptsFilter(compileDependencies);
   return {
     name: 'ice-pkg:swc',
 

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -90,6 +90,11 @@ export interface BundleUserConfig {
    * In the next version(v2), the value of polyfill will be `false`.
    */
   polyfill?: false | 'entry' | 'usage';
+
+  /**
+   * Weather or not compile the dependencies in node_modules.
+   */
+  compileDependencies?: boolean | RegExp[];
 }
 
 export interface UserConfig {

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -286,11 +286,18 @@ export const stringifyObject = (obj: PlainObject) => {
   }, {});
 };
 
-export const scriptsFilter = createFilter(
-  /\.m?[jt]sx?$/, // include
-  [/\.d\.ts$/], // exclude
-);
-
+export const createScriptsFilter = (compileDependencies?: boolean | RegExp[]) => {
+  const exclude = [/\.d\.ts$/];
+  if (Array.isArray(compileDependencies)) {
+    exclude.push(...compileDependencies);
+  } else if (compileDependencies) {
+    exclude.push(/node_modules/);
+  }
+  return createFilter(
+    /\.m?[jt]sx?$/, // include
+    exclude,
+  );
+};
 export const cwd = process.cwd();
 
 export function normalizeSlashes(file: string) {

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -290,7 +290,7 @@ export const createScriptsFilter = (compileDependencies?: boolean | RegExp[]) =>
   const exclude = [/\.d\.ts$/];
   if (Array.isArray(compileDependencies)) {
     exclude.push(...compileDependencies);
-  } else if (compileDependencies) {
+  } else if (!compileDependencies) {
     exclude.push(/node_modules/);
   }
   return createFilter(

--- a/website/docs/reference/config.md
+++ b/website/docs/reference/config.md
@@ -441,6 +441,23 @@ export default defineConfig({
 `polyfill` 默认值将会在下个 BK 版本改成 `false`。推荐组件的 bundle 产物不引入任何 polyfill（也就是设置成 `false`），而是使用 CDN 的方式引入 polyfill。
 :::
 
+#### compileDependencies
+
++ 类型：`boolean | RegExp[]`
++ 默认值：`false`
+
+配置是否编译 node_modules 中的依赖。如果值为 `true`，则 node_modules 中的依赖都会编译；如果值为 false 则都不编译；如果值为数组，则只会编译对应的依赖。
+
+```js title="build.config.mts"
+import { defineConfig } from '@ice/pkg';
+
+export default defineConfig({
+  bundle: {
+    compileDependencies: [/antd/],
+  },
+});
+```
+
 #### development
 
 :::caution


### PR DESCRIPTION
之前的 [PR](https://github.com/ice-lab/icepkg/pull/552)，默认就会把所有的 node_modules 下的依赖都编译了一遍，导致跟之前版本有 Break Change。比如：
<img width="1094" alt="image" src="https://github.com/ice-lab/icepkg/assets/44047106/8983b8eb-c77a-48b5-a60a-345ae079c6d8">

classnames 的源文件就只有一个 IIFE，没有任何导出，导致在打包编译过程中会找不到任何导出，就会出现上面的报错。

因此需要增加一个配置项来决定是否要编译 node_modules 