### PR TITLE
fix: specify type module in package.json will occur build error

### DIFF
--- a/.changeset/heavy-kids-play.md
+++ b/.changeset/heavy-kids-play.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: react package.json in root dir

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -1,7 +1,7 @@
 import path from 'path';
 import consola from 'consola';
 import { fileURLToPath } from 'url';
-import fs from 'fs-extra';
+import fse from 'fs-extra';
 import hbs from 'handlebars';
 import { createRequire } from 'module';
 import { DOCUSAURUS_DIR, DOCUSAURUS_CONFIG_FILE, DOCUSAURUS_BABEL_CONFIG_FILE } from './constants.mjs';
@@ -29,7 +29,7 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
     ? params?.sidebarItemsGenerator.toString()
     : false;
 
-  const haveStaticFiles = fs.pathExistsSync(path.join(rootDir, 'static'));
+  const haveStaticFiles = fse.pathExistsSync(path.join(rootDir, 'static'));
   const mobilePreview = !!params.mobilePreview;
 
   const prismReactRendererPath = path.dirname(require.resolve('prism-react-renderer/package.json', {
@@ -37,7 +37,7 @@ export function configureDocusaurus(rootDir: string, params: ConfigureDocusaurus
   }));
 
   const templatePath = path.join(__dirname, './template/docusaurus.hbs');
-  const templateContents = fs.readFileSync(templatePath, 'utf-8');
+  const templateContents = fse.readFileSync(templatePath, 'utf-8');
 
   const targetContents = hbs.compile(templateContents)({
     ...params,
@@ -103,15 +103,21 @@ module.exports = {
 
   // Write config to .docusaurus
   const output = path.join(rootDir, DOCUSAURUS_DIR);
-  fs.ensureDirSync(output);
-  fs.writeFileSync(path.join(output, DOCUSAURUS_CONFIG_FILE), targetContents, 'utf-8');
+  fse.ensureDirSync(output);
+
+  // write a empty package.json to avoid docusaurus read the package.json in the root dir
+  fse.writeJSONSync(path.join(output, 'package.json'), {});
+
+  // docusaurus config
+  fse.writeFileSync(path.join(output, DOCUSAURUS_CONFIG_FILE), targetContents, 'utf-8');
+
   // babel config for rax components doc build
-  fs.writeFileSync(
+  fse.writeFileSync(
     path.join(output, DOCUSAURUS_BABEL_CONFIG_FILE), babelConfigContents, 'utf-8',
   );
 
   // hijack createElement to support rpx in demo preview
-  fs.writeFileSync(
+  fse.writeFileSync(
     path.join(output, 'hijackCreateElement.js'), hijackCreateElementModuleContent, 'utf-8',
   );
 }


### PR DESCRIPTION
Docusaurus 启动的时候，目前是读取根目录的 package.json，如果 package.json 中指定了 type: module，则 `.docusaurus` 临时目录的文件（是 docusaurus 生成的）将会报错
<img width="605" alt="image" src="https://github.com/ice-lab/icepkg/assets/44047106/be978226-af46-4924-b85a-1ee30e111c3a">
<img width="981" alt="image" src="https://github.com/ice-lab/icepkg/assets/44047106/eda9a06a-128f-48e5-8199-26c1ad18d0a1">
