### PR TITLE
fix: not resolve package in docs

### DIFF
--- a/.changeset/beige-numbers-wink.md
+++ b/.changeset/beige-numbers-wink.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-docusaurus': patch
+---
+
+fix: not resolve package in docs

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -59,7 +59,7 @@
     "magic-string": "^0.25.7",
     "picocolors": "^1.0.0",
     "postcss": "^8.4.6",
-    "rollup": "^2.62.0",
+    "rollup": "^2.79.1",
     "rollup-plugin-styles": "^4.0.0",
     "rollup-plugin-visualizer": "^5.8.3",
     "semver": "^7.0.0",

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -121,6 +121,7 @@ module.exports = {
     path.join(output, 'hijackCreateElement.js'), hijackCreateElementModuleContent, 'utf-8',
   );
 
+  // A package.json exists in the .docusaurus file, to fix the package can not be required in md file(docs)
   createSymbolicLink(
     rootDir,
     path.join(rootDir, 'node_modules', require(path.join(rootDir, 'package.json')).name),

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -120,4 +120,16 @@ module.exports = {
   fse.writeFileSync(
     path.join(output, 'hijackCreateElement.js'), hijackCreateElementModuleContent, 'utf-8',
   );
+
+  createSymbolicLink(
+    rootDir,
+    path.join(rootDir, 'node_modules', require(path.join(rootDir, 'package.json')).name),
+  );
+}
+
+function createSymbolicLink(src: string, dest: string) {
+  if (fse.pathExistsSync(dest) && fse.lstatSync(dest)) {
+    fse.unlinkSync(dest);
+  }
+  fse.symlinkSync(src, dest);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,19 +349,19 @@ importers:
         version: 7.18.6(@babel/core@7.18.6)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.0
-        version: 25.0.0(rollup@2.76.0)
+        version: 25.0.0(rollup@2.79.1)
       '@rollup/plugin-image':
         specifier: ^3.0.1
-        version: 3.0.1(rollup@2.76.0)
+        version: 3.0.1(rollup@2.79.1)
       '@rollup/plugin-json':
         specifier: ^4.1.0
-        version: 4.1.0(rollup@2.76.0)
+        version: 4.1.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve':
         specifier: ^15.0.2
-        version: 15.0.2(rollup@2.76.0)
+        version: 15.0.2(rollup@2.79.1)
       '@rollup/plugin-replace':
         specifier: ^5.0.1
-        version: 5.0.1(rollup@2.76.0)
+        version: 5.0.1(rollup@2.79.1)
       '@rollup/pluginutils':
         specifier: ^4.1.2
         version: 4.2.1
@@ -417,14 +417,14 @@ importers:
         specifier: ^8.4.6
         version: 8.4.14
       rollup:
-        specifier: ^2.62.0
-        version: 2.76.0
+        specifier: ^2.79.1
+        version: 2.79.1
       rollup-plugin-styles:
         specifier: ^4.0.0
-        version: 4.0.0(rollup@2.76.0)
+        version: 4.0.0(rollup@2.79.1)
       rollup-plugin-visualizer:
         specifier: ^5.8.3
-        version: 5.8.3(rollup@2.76.0)
+        version: 5.8.3(rollup@2.79.1)
       semver:
         specifier: ^7.0.0
         version: 7.3.7
@@ -7052,7 +7052,7 @@ packages:
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
 
-  /@rollup/plugin-commonjs@25.0.0(rollup@2.76.0):
+  /@rollup/plugin-commonjs@25.0.0(rollup@2.79.1):
     resolution: {integrity: sha512-hoho2Kay9TZrLu0bnDsTTCaj4Npa+THk9snajP/XDNb9a9mmjTjh52EQM9sKl3HD1LsnihX7js+eA2sd2uKAhw==, tarball: '@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-25.0.0.tgz'}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7061,16 +7061,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.76.0)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-image@3.0.1(rollup@2.76.0):
+  /@rollup/plugin-image@3.0.1(rollup@2.79.1):
     resolution: {integrity: sha512-F50Sko4Xcc576x7HG9f3MvJKKnBfSmqfVFWJkJgyIEkI8YxZxux28lDbuy0+GsAK6BFl9Gn+TRXOUgHHJbFh3w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7079,21 +7079,21 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.76.0)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       mini-svg-data-uri: 1.4.4
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-json@4.1.0(rollup@2.76.0):
+  /@rollup/plugin-json@4.1.0(rollup@2.79.1):
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.76.0)
-      rollup: 2.76.0
+      '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
+      rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-node-resolve@15.0.2(rollup@2.76.0):
+  /@rollup/plugin-node-resolve@15.0.2(rollup@2.79.1):
     resolution: {integrity: sha512-Y35fRGUjC3FaurG722uhUuG8YHOJRJQbI6/CkbRkdPotSpDj9NtIN85z1zrcyDcCQIW4qp5mgG72U+gJ0TAFEg==, tarball: '@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-15.0.2.tgz'}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7102,16 +7102,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.76.0)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-replace@5.0.1(rollup@2.76.0):
+  /@rollup/plugin-replace@5.0.1(rollup@2.79.1):
     resolution: {integrity: sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7120,12 +7120,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.76.0)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       magic-string: 0.26.7
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
-  /@rollup/pluginutils@3.1.0(rollup@2.76.0):
+  /@rollup/pluginutils@3.1.0(rollup@2.79.1):
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -7134,7 +7134,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
   /@rollup/pluginutils@4.2.1:
@@ -7145,7 +7145,7 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@rollup/pluginutils@5.0.2(rollup@2.76.0):
+  /@rollup/pluginutils@5.0.2(rollup@2.79.1):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==, tarball: '@rollup/pluginutils/download/@rollup/pluginutils-5.0.2.tgz'}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7157,7 +7157,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 2.76.0
+      rollup: 2.79.1
     dev: false
 
   /@sideway/address@4.1.4:
@@ -17932,7 +17932,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-styles@4.0.0(rollup@2.76.0):
+  /rollup-plugin-styles@4.0.0(rollup@2.79.1):
     resolution: {integrity: sha512-A2K2sao84OsTmDxXG83JTCdXWrmgvQkkI38XDat46rdtpGMRm9tSYqeCdlwwGDJF4kKIafhV1mUidqu8MxUGig==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
@@ -17954,12 +17954,12 @@ packages:
       postcss-value-parser: 4.2.0
       query-string: 7.1.3
       resolve: 1.22.1
-      rollup: 2.76.0
+      rollup: 2.79.1
       source-map-js: 1.0.2
       tslib: 2.4.0
     dev: false
 
-  /rollup-plugin-visualizer@5.8.3(rollup@2.76.0):
+  /rollup-plugin-visualizer@5.8.3(rollup@2.79.1):
     resolution: {integrity: sha512-QGJk4Bqe4AOat5AjipOh8esZH1nck5X2KFpf4VytUdSUuuuSwvIQZjMGgjcxe/zXexltqaXp5Vx1V3LmnQH15Q==}
     engines: {node: '>=14'}
     hasBin: true
@@ -17970,13 +17970,13 @@ packages:
         optional: true
     dependencies:
       open: 8.4.0
-      rollup: 2.76.0
+      rollup: 2.79.1
       source-map: 0.7.4
       yargs: 17.5.1
     dev: false
 
-  /rollup@2.76.0:
-    resolution: {integrity: sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==}
+  /rollup@2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:


### PR DESCRIPTION
关联 #560 

在 md 文件中显示声明引入当前 npm 包时，无法正确 require 到。这是因为向上逐层查找 node_modules 是否有此 npm 包，发现并没有。解决方案是通过软链接的方式链到根目录 node_modules 