### PR TITLE
feat: auto import `rax.Fragment` component

### DIFF
--- a/.changeset/beige-cups-tease.md
+++ b/.changeset/beige-cups-tease.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg-plugin-rax-component': patch
+---
+
+feat: auto import `rax.Fragment` component

--- a/examples/rax-component/src/index.tsx
+++ b/examples/rax-component/src/index.tsx
@@ -1,4 +1,4 @@
-import { createElement, Fragment } from 'rax';
+import { createElement } from 'rax';
 import styles from './index.module.css';
 import Header from './components/Header';
 

--- a/packages/plugin-rax-component/src/index.ts
+++ b/packages/plugin-rax-component/src/index.ts
@@ -12,6 +12,7 @@ const plugin: Plugin = (api) => {
             react: {
               // Use classic jsx transform, see https://swc.rs/docs/configuration/compilation#jsctransformreactruntime
               runtime: 'classic',
+              importSource: 'rax',
               pragma: 'createElement',
               pragmaFrag: 'Fragment',
             },


### PR DESCRIPTION
rax 组件中使用了 `<> </>`，编译会直接成 `Fragment()`，如果没有从 rax 显式引入 Fragment 组件，可能导致组件在消费时找不到对应的组件