### PR TITLE
fix: symlink error when dir doesn't exists

### DIFF
--- a/packages/plugin-docusaurus/CHANGELOG.md
+++ b/packages/plugin-docusaurus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.13
+
+### Patch Changes
+
+- fix: symlink error when dir doesn't exist
+
 ## 1.4.12
 
 ### Patch Changes

--- a/packages/plugin-docusaurus/package.json
+++ b/packages/plugin-docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg-plugin-docusaurus",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "@ice/pkg plugin for component and docs preview.",
   "main": "es2017/index.mjs",
   "exports": {

--- a/packages/plugin-docusaurus/src/configureDocusaurus.mts
+++ b/packages/plugin-docusaurus/src/configureDocusaurus.mts
@@ -132,5 +132,6 @@ function createSymbolicLink(src: string, dest: string) {
   if (fse.pathExistsSync(dest) && fse.lstatSync(dest)) {
     fse.unlinkSync(dest);
   }
-  fse.symlinkSync(src, dest);
+
+  fse.ensureSymlinkSync(src, dest);
 }


### PR DESCRIPTION
<img width="723" alt="image" src="https://github.com/ice-lab/icepkg/assets/44047106/95aacdb0-dd75-4265-a5dd-4960411783ae">

如果父路径不存在，则在进行创建软链接过程中会出现路径不存在的报错。使用 [fs.ensureSymlinkSync](https://github.com/jprichardson/node-fs-extra/blob/master/docs/ensureSymlink-sync.md) 可以保证父路径存在