### PR TITLE
docs: fix create pkg with workspace cli flag

### DIFF
--- a/website/docs/guide/monorepo.md
+++ b/website/docs/guide/monorepo.md
@@ -17,7 +17,7 @@ ICE PKG 的 Monorepo 方案是基于 [pnpm workspace](https://pnpm.io/workspaces
 通过以下命令，可以快速初始化一个 Monorepo 项目：
 
 ```bash
-$ npm init @ice/pkg my-monorepo
+$ pnpm create @ice/pkg my-monorepo
 ```
 
 选择 React 组件项目类型：
@@ -56,7 +56,7 @@ $ npm init @ice/pkg my-monorepo
 
 ```shell
 # 假设 packages 目录是用于存放子项目
-$ npm init @ice/pkg -w packages/your-lib
+$ pnpm create @ice/pkg packages/your-lib --workspace
 ```
 
 执行成功后，你将会看到以下内容：

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -23,7 +23,7 @@ $ cnpm -v
 以 React 组件类型为例，通过以下命令，可以快速初始化一个项目：
 
 ```bash
-$ npm init @ice/pkg react-component
+$ npm init @ice/pkg@latest react-component
 ```
 
 选择 React 组件项目类型：
@@ -38,7 +38,7 @@ $ npm init @ice/pkg react-component
 你还可以通过附加的命令行选项的方式指定你想要的模板和 npm 包名，比如：
 
 ```bash
-$ npm init @ice/pkg react-component --template @ice/template-pkg-react --npmName my-react-component
+$ npm init @ice/pkg@latest react-component --template @ice/template-pkg-react --npmName my-react-component
 ```
 
 ## 启动项目


### PR DESCRIPTION
在 npm v7 使用以下方式创建子包，会导致 -w 参数无法传递过去。一般需要加 `--`
```diff
- $ npm init @ice/pkg -w packages/your-lib
+ $ npm init @ice/pkg -- -w packages/your-lib
```

Monorepo 章节统一使用 pnpm 操作。

另外，顺带修改『快速开始』章节的创建项目部分，增加 @latest 确保每次都使用最新的 cli 版本进行创建