### PR TITLE
fix: not bundle cjs module

### DIFF
--- a/.changeset/giant-stingrays-sleep.md
+++ b/.changeset/giant-stingrays-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: not bundle cjs module

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -126,8 +126,10 @@ export function getRollupOptions(
       commonjs({ // To convert commonjs to import, make it compatible with rollup to bundle
         extensions: [
           '.js', // plugin-commonjs default extensions
+          '.jsx', '.ts', '.tsx',
           ...(taskConfig.extensions || []),
         ],
+        transformMixedEsModules: true,
       }),
     );
     if (commandArgs.analyzer) {


### PR DESCRIPTION
对于 esm 和 cjs 混用的场景，比如：
```jsx
// src/index.tsx
import xx from 'xx';

const a = require('xxx');
```

对于 @rollup/plugin-commonjs 来说，默认不会处理 esm 和 cjs 混用的场景，也就是 cjs 模块不会打包进去 bundle 里面。但是现存的业务有较多类似的情况。因此在 pkg 这层兼容。

Note: 增加 extensions 是为了让 plugin-commonjs 也处理 tsx, jsx, ts 中有 require 的情况