### PR TITLE
fix: generate type with private type error

### DIFF
--- a/.changeset/few-crabs-sneeze.md
+++ b/.changeset/few-crabs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: generate types with private type error

--- a/examples/react-component/src/components/Button/index.tsx
+++ b/examples/react-component/src/components/Button/index.tsx
@@ -20,6 +20,8 @@ interface ButtonProps {
   onClick?: React.MouseEventHandler;
 }
 
+export const app: Application = { add: () => Promise.resolve(1) };
+
 const Button: React.FunctionComponent<React.PropsWithChildren<ButtonProps>> = (props: ButtonProps) => {
   const {
     type = 'default',

--- a/examples/react-component/src/typings.d.ts
+++ b/examples/react-component/src/typings.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="@ice/pkg/types" />
+
+interface Application {
+  add: () => Promise<number>;
+}

--- a/packages/pkg/src/helpers/dts.ts
+++ b/packages/pkg/src/helpers/dts.ts
@@ -90,6 +90,8 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
 
   // In order to only include the update files instead of all the files in the watch mode.
   function getProgramRootNames(originalFilenames: string[]) {
+    // Should include all the resolved .d.ts file to avoid dts generate error:
+    // TS4025: Exported variable '<name>' has or is using private name '<name>'.
     const dtsFilenames = originalFilenames.filter((filename) => filename.endsWith('.d.ts'));
     const needCompileFileNames = _files.map(({ filePath }) => filePath);
     return [...needCompileFileNames, ...dtsFilenames];

--- a/packages/pkg/src/helpers/dts.ts
+++ b/packages/pkg/src/helpers/dts.ts
@@ -8,6 +8,7 @@ import type { TaskConfig } from '../types.js';
 import { prepareSingleFileReplaceTscAliasPaths } from 'tsc-alias';
 import fse from 'fs-extra';
 import * as path from 'path';
+import merge from 'lodash.merge';
 
 export type FileExt = 'js' | 'ts' | 'tsx' | 'jsx' | 'mjs' | 'mts';
 
@@ -39,7 +40,7 @@ const normalizeDtsInput = (file: File, rootDir: string, outputDir: string): DtsI
 };
 
 interface DtsCompileOptions {
-
+  // In watch mode, it only contains the updated file names. In build mode, it contains all file names.
   files: File[];
   alias: TaskConfig['alias'];
   rootDir: string;
@@ -52,16 +53,7 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
     return;
   }
 
-  const tsCompilerOptions: ts.CompilerOptions = {
-    allowJs: true,
-    declaration: true,
-    emitDeclarationOnly: true,
-    incremental: true,
-    skipLibCheck: true,
-    outDir: outputDir,
-    rootDir: path.join(rootDir, 'src'),
-    paths: formatAliasToTSPathsConfig(alias),
-  };
+  const tsConfig = await getTSConfig(rootDir, outputDir, alias);
 
   const logger = createLogger('dts');
 
@@ -81,7 +73,7 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
   const dtsFiles = {};
 
   // Create ts host and custom the writeFile and readFile.
-  const host = ts.createCompilerHost(tsCompilerOptions);
+  const host = ts.createCompilerHost(tsConfig.options);
   host.writeFile = (fileName, contents) => {
     dtsFiles[fileName] = contents;
   };
@@ -96,12 +88,22 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
     return _readFile(fileName);
   };
 
+  // In order to only include the update files instead of all the files in the watch mode.
+  function getProgramRootNames(originalFilenames: string[]) {
+    const dtsFilenames = originalFilenames.filter((filename) => filename.endsWith('.d.ts'));
+    const needCompileFileNames = _files.map(({ filePath }) => filePath);
+    return [...needCompileFileNames, ...dtsFilenames];
+  }
+
   // Create ts program.
-  const program = ts.createProgram(
-    _files.map(({ filePath }) => filePath),
-    tsCompilerOptions,
+  const programOptions: ts.CreateProgramOptions = {
+    rootNames: getProgramRootNames(tsConfig.fileNames),
+    options: tsConfig.options,
     host,
-  );
+    projectReferences: tsConfig.projectReferences,
+    configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(tsConfig),
+  };
+  const program = ts.createProgram(programOptions);
 
   logger.debug(`Initializing program takes ${timeFrom(dtsCompileStart)}`);
 
@@ -123,10 +125,8 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
   // Reason: https://github.com/microsoft/TypeScript/issues/30952#issuecomment-1114225407
   const tsConfigLocalPath = path.join(rootDir, 'node_modules/pkg/tsconfig.json');
   await fse.ensureFile(tsConfigLocalPath);
-  await fse.writeJSON(
-    tsConfigLocalPath,
-    { compilerOptions: tsCompilerOptions },
-  );
+  await fse.writeJSON(tsConfigLocalPath, tsConfig, { spaces: 2 });
+
   const runFile = await prepareSingleFileReplaceTscAliasPaths({
     configFile: tsConfigLocalPath,
     outDir: outputDir,
@@ -140,4 +140,50 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
   logger.debug(`Generating declaration files take ${timeFrom(dtsCompileStart)}`);
 
   return result;
+}
+
+async function getTSConfig(
+  rootDir: string,
+  outputDir: string,
+  alias: TaskConfig['alias'],
+) {
+  const defaultTSCompilerOptions: ts.CompilerOptions = {
+    allowJs: true,
+    declaration: true,
+    emitDeclarationOnly: true,
+    incremental: true,
+    skipLibCheck: true,
+    paths: formatAliasToTSPathsConfig(alias), // default add alias to paths
+  };
+  const projectTSConfig = await getProjectTSConfig(rootDir);
+  const tsConfig: ts.ParsedCommandLine = merge(
+    { options: defaultTSCompilerOptions },
+    projectTSConfig,
+    {
+      options: {
+        outDir: outputDir,
+        rootDir: path.join(rootDir, 'src'),
+      },
+    },
+  );
+
+  return tsConfig;
+}
+
+async function getProjectTSConfig(rootDir: string): Promise<ts.ParsedCommandLine> {
+  const tsconfigPath = ts.findConfigFile(rootDir, ts.sys.fileExists);
+  if (tsconfigPath) {
+    const tsconfigFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+    return ts.parseJsonConfigFileContent(
+      tsconfigFile.config,
+      ts.sys,
+      path.dirname(tsconfigPath),
+    );
+  }
+
+  return {
+    options: {},
+    fileNames: [],
+    errors: [],
+  };
 }


### PR DESCRIPTION
如果某些类型直接被定义在 `.d.ts` 文件中，在实际的 `.ts` 文件中通过全局类型的方式使用，而不是通过模块导入的形式使用。比如：
```ts
// types.d.ts
interface Application {
  onClick: () => void;
}
```

```ts
// src/index.ts
export app: Application = {
 onClick: () => {}
}
```

生成 d.ts 文件时候会报错：`TS4025: Exported variable '<name>' has or is using private name '<name>'.`

解决的办法是，在 `ts.createProgram(programOptions)` 中，`programOptions.rootNames` 要把对应的 `d.ts` 声明文件包含，才能编译成功。
