### PR TITLE
fix: dts maybe failed

### DIFF
--- a/.changeset/slow-students-shop.md
+++ b/.changeset/slow-students-shop.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+filter the failed dts file

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmmirror.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.npmmirror.com
+registry=https://registry.npmjs.org

--- a/packages/pkg/src/helpers/dts.ts
+++ b/packages/pkg/src/helpers/dts.ts
@@ -134,7 +134,7 @@ export async function dtsCompile({ files, alias, rootDir, outputDir }: DtsCompil
 
   const result = _files.map((file) => ({
     ...file,
-    dtsContent: runFile({ fileContents: dtsFiles[file.dtsPath], filePath: file.dtsPath }),
+    dtsContent: dtsFiles[file.dtsPath] ? runFile({ fileContents: dtsFiles[file.dtsPath], filePath: file.dtsPath }) : '',
   }));
 
   logger.debug(`Generating declaration files take ${timeFrom(dtsCompileStart)}`);


### PR DESCRIPTION
修复dts生成失败时 `dtsFiles` 和 `_file` 不匹配的问题，tsc-alias的source为必填项 否则会报错
 避免dts的生成阻塞构建
[reproduce repo](https://github.com/HomyeeKing/icepkg-repro)