### PR TITLE
feat: support modify vendor name

### DIFF
--- a/.changeset/hip-oranges-reflect.md
+++ b/.changeset/hip-oranges-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+feat: support modify vendors name

--- a/.changeset/hip-oranges-reflect.md
+++ b/.changeset/hip-oranges-reflect.md
@@ -1,5 +1,0 @@
----
-'@ice/pkg': patch
----
-
-feat: support modify vendor name

--- a/.changeset/hip-oranges-reflect.md
+++ b/.changeset/hip-oranges-reflect.md
@@ -2,4 +2,4 @@
 '@ice/pkg': patch
 ---
 
-feat: support modify vendors name
+feat: support modify vendor name

--- a/packages/pkg/CHANGELOG.md
+++ b/packages/pkg/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.13
+
+### Patch Changes
+
+- 1de94aa: feat: support modify vendor name
+
 ## 1.5.12
 
 ### Patch Changes

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "A fast builder for React components, Node modules and web libraries.",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -165,7 +165,7 @@ function getRollupOutputs({
   esVersion,
   command,
 }: GetRollupOutputsOptions): OutputOptions[] {
-  const defaultVendorsName = 'vendors';
+  const defaultVendorsName = 'vendor';
   const { outputDir, modifyVendorsName = (vendorsName: string) => vendorsName } = bundleTaskConfig;
 
   const outputFormats = (bundleTaskConfig.formats || []).filter((format) => format !== 'es2017') as Array<'umd' | 'esm' | 'cjs'>;

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -165,12 +165,16 @@ function getRollupOutputs({
   esVersion,
   command,
 }: GetRollupOutputsOptions): OutputOptions[] {
-  const { outputDir } = bundleTaskConfig;
+  const defaultVendorsName = 'vendors';
+  const { outputDir, modifyVendorsName = (vendorsName: string) => vendorsName } = bundleTaskConfig;
 
   const outputFormats = (bundleTaskConfig.formats || []).filter((format) => format !== 'es2017') as Array<'umd' | 'esm' | 'cjs'>;
 
   const name = bundleTaskConfig.name ?? pkg.name;
   const minify = bundleTaskConfig.jsMinify(mode, command);
+
+  const vendorsName = modifyVendorsName(defaultVendorsName);
+
   return outputFormats.map((format) => ({
     name,
     format,
@@ -183,7 +187,7 @@ function getRollupOutputs({
     chunkFileNames: getFilename('[name]', format, esVersion, mode, 'js'),
     manualChunks: format !== 'umd' ? (id, { getModuleInfo }) => {
       if (/node_modules/.test(id)) {
-        return 'vendor';
+        return vendorsName;
       }
 
       const entryPoints = [];
@@ -204,7 +208,7 @@ function getRollupOutputs({
       }
       // For multiple entries, we put it into a "shared code" bundle
       if (entryPoints.length > 1) {
-        return 'vendor';
+        return vendorsName;
       }
     } : undefined,
     plugins: [

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -165,15 +165,15 @@ function getRollupOutputs({
   esVersion,
   command,
 }: GetRollupOutputsOptions): OutputOptions[] {
-  const defaultVendorsName = 'vendor';
-  const { outputDir, modifyVendorsName = (vendorsName: string) => vendorsName } = bundleTaskConfig;
+  const defaultVendorName = 'vendor';
+  const { outputDir, modifyVendorName = (vendorName: string) => vendorName } = bundleTaskConfig;
 
   const outputFormats = (bundleTaskConfig.formats || []).filter((format) => format !== 'es2017') as Array<'umd' | 'esm' | 'cjs'>;
 
   const name = bundleTaskConfig.name ?? pkg.name;
   const minify = bundleTaskConfig.jsMinify(mode, command);
 
-  const vendorsName = modifyVendorsName(defaultVendorsName);
+  const vendorName = modifyVendorName(defaultVendorName);
 
   return outputFormats.map((format) => ({
     name,
@@ -187,7 +187,7 @@ function getRollupOutputs({
     chunkFileNames: getFilename('[name]', format, esVersion, mode, 'js'),
     manualChunks: format !== 'umd' ? (id, { getModuleInfo }) => {
       if (/node_modules/.test(id)) {
-        return vendorsName;
+        return vendorName;
       }
 
       const entryPoints = [];
@@ -208,7 +208,7 @@ function getRollupOutputs({
       }
       // For multiple entries, we put it into a "shared code" bundle
       if (entryPoints.length > 1) {
-        return vendorsName;
+        return vendorName;
       }
     } : undefined,
     plugins: [

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -165,15 +165,12 @@ function getRollupOutputs({
   esVersion,
   command,
 }: GetRollupOutputsOptions): OutputOptions[] {
-  const defaultVendorName = 'vendor';
-  const { outputDir, modifyVendorName = (vendorName: string) => vendorName } = bundleTaskConfig;
+  const { outputDir, vendorName = 'vendor' } = bundleTaskConfig;
 
   const outputFormats = (bundleTaskConfig.formats || []).filter((format) => format !== 'es2017') as Array<'umd' | 'esm' | 'cjs'>;
 
   const name = bundleTaskConfig.name ?? pkg.name;
   const minify = bundleTaskConfig.jsMinify(mode, command);
-
-  const vendorName = modifyVendorName(defaultVendorName);
 
   return outputFormats.map((format) => ({
     name,

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -219,7 +219,7 @@ export interface BundleTaskConfig extends
 
   cssMinify?: (mode: string, command: string) => CSSMinify;
 
-  modifyVendorName?: (defaultVendorName: string) => string;
+  vendorName?: string;
 }
 
 export interface TransformTaskConfig extends _TaskConfig, TransformUserConfig {

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -218,6 +218,8 @@ export interface BundleTaskConfig extends
   jsMinify?: (mode: string, command: string) => JSMinify;
 
   cssMinify?: (mode: string, command: string) => CSSMinify;
+
+  modifyVendorsName?: (defaultVendorsName: string) => string;
 }
 
 export interface TransformTaskConfig extends _TaskConfig, TransformUserConfig {

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -219,7 +219,7 @@ export interface BundleTaskConfig extends
 
   cssMinify?: (mode: string, command: string) => CSSMinify;
 
-  modifyVendorsName?: (defaultVendorsName: string) => string;
+  modifyVendorName?: (defaultVendorName: string) => string;
 }
 
 export interface TransformTaskConfig extends _TaskConfig, TransformUserConfig {


### PR DESCRIPTION
bundle 模式下，如果不同的 task(比如一个 weex，一个 web )均产生 vendor，因为 vendor 文件同名的原因，那么后面产出的 vendor 会覆盖掉前面的 vendor。

因此需要支持每个 task 定制自己的 vendor name