### PR TITLE
fix: compile all deps when specify deps in compileDependencies

### DIFF
--- a/.changeset/giant-wolves-press.md
+++ b/.changeset/giant-wolves-press.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: compile all deps when specify deps in compileDependencies

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -4,7 +4,7 @@
 import * as babel from '@babel/core';
 import type { ParserPlugin } from '@babel/parser';
 import { Plugin } from 'rollup';
-import { createScriptsFilter, formatCnpmDepFilepath, getExcludeNodeModules } from '../utils.js';
+import { createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModules } from '../utils.js';
 import type { BundleTaskConfig } from '../types.js';
 import { TransformOptions } from '@babel/core';
 import getBabelOptions from '../helpers/getBabelOptions.js';
@@ -43,7 +43,7 @@ const babelPlugin = (
 ): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const babelOptions = getBabelOptions(plugins, options, modifyBabelOptions);
-  const scriptsFilter = createScriptsFilter([], getExcludeNodeModules(compileDependencies));
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
   return {
     name: 'ice-pkg:babel',
 

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -4,7 +4,7 @@
 import * as babel from '@babel/core';
 import type { ParserPlugin } from '@babel/parser';
 import { Plugin } from 'rollup';
-import { createScriptsFilter } from '../utils.js';
+import { createScriptsFilter, formatCnpmDepFilepath, getExcludeNodeModules } from '../utils.js';
 import type { BundleTaskConfig } from '../types.js';
 import { TransformOptions } from '@babel/core';
 import getBabelOptions from '../helpers/getBabelOptions.js';
@@ -43,12 +43,12 @@ const babelPlugin = (
 ): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const babelOptions = getBabelOptions(plugins, options, modifyBabelOptions);
-  const scriptsFilter = createScriptsFilter(compileDependencies);
+  const scriptsFilter = createScriptsFilter([], getExcludeNodeModules(compileDependencies));
   return {
     name: 'ice-pkg:babel',
 
     transform(source, id) {
-      if (!scriptsFilter(id)) {
+      if (!scriptsFilter(formatCnpmDepFilepath(id))) {
         return null;
       }
 

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -43,7 +43,7 @@ const babelPlugin = (
 ): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const babelOptions = getBabelOptions(plugins, options, modifyBabelOptions);
-  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies), [/@babel\/runtime/, /babel-runtime/]);
   return {
     name: 'ice-pkg:babel',
 

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -4,7 +4,7 @@
 import * as babel from '@babel/core';
 import type { ParserPlugin } from '@babel/parser';
 import { Plugin } from 'rollup';
-import { createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModules } from '../utils.js';
+import { createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModuleScripts } from '../utils.js';
 import type { BundleTaskConfig } from '../types.js';
 import { TransformOptions } from '@babel/core';
 import getBabelOptions from '../helpers/getBabelOptions.js';
@@ -43,7 +43,7 @@ const babelPlugin = (
 ): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const babelOptions = getBabelOptions(plugins, options, modifyBabelOptions);
-  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModuleScripts(compileDependencies));
   return {
     name: 'ice-pkg:babel',
 

--- a/packages/pkg/src/rollupPlugins/babel.ts
+++ b/packages/pkg/src/rollupPlugins/babel.ts
@@ -43,7 +43,7 @@ const babelPlugin = (
 ): Plugin => {
   // https://babeljs.io/docs/en/babel-preset-react#usage
   const babelOptions = getBabelOptions(plugins, options, modifyBabelOptions);
-  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies), [/@babel\/runtime/, /babel-runtime/]);
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
   return {
     name: 'ice-pkg:babel',
 

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -2,7 +2,7 @@ import { extname, basename, relative, sep } from 'path';
 import * as swc from '@swc/core';
 import deepmerge from 'deepmerge';
 import { isTypescriptOnly } from '../helpers/suffix.js';
-import { checkDependencyExists, createScriptsFilter, formatCnpmDepFilepath, getExcludeNodeModules } from '../utils.js';
+import { checkDependencyExists, createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModules } from '../utils.js';
 
 import type { Options as swcCompileOptions, Config, TsParserConfig, EsParserConfig } from '@swc/core';
 import type { TaskConfig, OutputFile, BundleTaskConfig } from '../types.js';
@@ -65,7 +65,7 @@ const swcPlugin = (
   extraSwcOptions?: Config,
   compileDependencies?: BundleTaskConfig['compileDependencies'],
 ): Plugin => {
-  const scriptsFilter = createScriptsFilter([], getExcludeNodeModules(compileDependencies));
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
   return {
     name: 'ice-pkg:swc',
 

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -2,7 +2,7 @@ import { extname, basename, relative, sep } from 'path';
 import * as swc from '@swc/core';
 import deepmerge from 'deepmerge';
 import { isTypescriptOnly } from '../helpers/suffix.js';
-import { checkDependencyExists, createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModules } from '../utils.js';
+import { checkDependencyExists, createScriptsFilter, formatCnpmDepFilepath, getIncludeNodeModuleScripts } from '../utils.js';
 
 import type { Options as swcCompileOptions, Config, TsParserConfig, EsParserConfig } from '@swc/core';
 import type { TaskConfig, OutputFile, BundleTaskConfig } from '../types.js';
@@ -66,7 +66,7 @@ const swcPlugin = (
   compileDependencies?: BundleTaskConfig['compileDependencies'],
 ): Plugin => {
   const scriptsFilter = createScriptsFilter(
-    getIncludeNodeModules(compileDependencies),
+    getIncludeNodeModuleScripts(compileDependencies),
   );
   return {
     name: 'ice-pkg:swc',

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -2,7 +2,7 @@ import { extname, basename, relative, sep } from 'path';
 import * as swc from '@swc/core';
 import deepmerge from 'deepmerge';
 import { isTypescriptOnly } from '../helpers/suffix.js';
-import { checkDependencyExists, createScriptsFilter } from '../utils.js';
+import { checkDependencyExists, createScriptsFilter, formatCnpmDepFilepath, getExcludeNodeModules } from '../utils.js';
 
 import type { Options as swcCompileOptions, Config, TsParserConfig, EsParserConfig } from '@swc/core';
 import type { TaskConfig, OutputFile, BundleTaskConfig } from '../types.js';
@@ -65,12 +65,12 @@ const swcPlugin = (
   extraSwcOptions?: Config,
   compileDependencies?: BundleTaskConfig['compileDependencies'],
 ): Plugin => {
-  const scriptsFilter = createScriptsFilter(compileDependencies);
+  const scriptsFilter = createScriptsFilter([], getExcludeNodeModules(compileDependencies));
   return {
     name: 'ice-pkg:swc',
 
     async transform(source, id) {
-      if (!scriptsFilter(id)) {
+      if (!scriptsFilter(formatCnpmDepFilepath(id))) {
         return null;
       }
 

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -67,7 +67,6 @@ const swcPlugin = (
 ): Plugin => {
   const scriptsFilter = createScriptsFilter(
     getIncludeNodeModules(compileDependencies),
-    [/@swc\/helpers/],
   );
   return {
     name: 'ice-pkg:swc',

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -65,7 +65,10 @@ const swcPlugin = (
   extraSwcOptions?: Config,
   compileDependencies?: BundleTaskConfig['compileDependencies'],
 ): Plugin => {
-  const scriptsFilter = createScriptsFilter(getIncludeNodeModules(compileDependencies));
+  const scriptsFilter = createScriptsFilter(
+    getIncludeNodeModules(compileDependencies),
+    [/@swc\/helpers/],
+  );
   return {
     name: 'ice-pkg:swc',
 

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -95,7 +95,7 @@ export interface BundleUserConfig {
   /**
    * Weather or not compile the dependencies in node_modules.
    */
-  compileDependencies?: boolean | RegExp[];
+  compileDependencies?: boolean | RegExp[] | string[];
 }
 
 export interface UserConfig {

--- a/packages/pkg/src/types.ts
+++ b/packages/pkg/src/types.ts
@@ -95,7 +95,7 @@ export interface BundleUserConfig {
   /**
    * Weather or not compile the dependencies in node_modules.
    */
-  compileDependencies?: boolean | RegExp[] | string[];
+  compileDependencies?: boolean | Array<RegExp | string>;
 }
 
 export interface UserConfig {

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -328,18 +328,6 @@ export const createScriptsFilter = (
   const exclude = [/\.d\.ts$/].concat(extraExclude);
   const include = [/\.m?[jt]sx?$/].concat(extraInclude);
 
-  // compileDependencies 默认值为 false
-
-
-  // if (Array.isArray(compileDependencies) && compileDependencies.length > 0) {
-  //   // compileDependencies 为 array 并且数组长度不为空时，编译指定依赖
-  //   // 例子：匹配除 @ice/abc 或者 abc 以外所有在 node_modules 下的依赖： node_modules(\/|\\\\)(?!(.*@ice\/abc|.*abc)).*(\/|\\\\).*
-  //   exclude.push(new RegExp(`node_modules(/|\\\\)(?!(${compileDependencies.map((dep) => (`.*${dep.source}`)).join('|')})).*(/|\\\\).*`));
-  // } else if (!compileDependencies) {
-  //   // compileDependencies 为 false 时，不编译任何依赖
-  //   exclude.push(/node_modules/);
-  // }
-
   return createFilter(include, exclude);
 };
 

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -288,15 +288,21 @@ export const stringifyObject = (obj: PlainObject) => {
 
 export const createScriptsFilter = (compileDependencies?: boolean | RegExp[]) => {
   const exclude = [/\.d\.ts$/];
-  if (Array.isArray(compileDependencies)) {
-    exclude.push(...compileDependencies);
+  const include = [/\.m?[jt]sx?$/];
+
+  // compileDependencies 默认值为 false
+
+  // compileDependencies 为 true 或空数组时，编译所有依赖，这里不需要做任何处理
+
+  if (Array.isArray(compileDependencies) && compileDependencies.length > 0) {
+    // compileDependencies 为 array 并且数组长度不为空时，编译指定依赖
+    // 例子：匹配除 @ice/abc 或者 abc 以外所有在 node_modules 下的依赖： node_modules(\/|\\\\)(?!(.*@ice\/abc|.*abc)).*(\/|\\\\).*
+    exclude.push(new RegExp(`node_modules(/|\\\\)(?!(${compileDependencies.map((dep) => (`.*${dep.source}`)).join('|')})).*(/|\\\\).*`));
   } else if (!compileDependencies) {
+    // compileDependencies 为 false 时，不编译任何依赖
     exclude.push(/node_modules/);
   }
-  return createFilter(
-    /\.m?[jt]sx?$/, // include
-    exclude,
-  );
+  return createFilter(include, exclude);
 };
 export const cwd = process.cwd();
 

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -337,7 +337,7 @@ export const createScriptsFilter = (
   extraExcludes: RegExp[] = [],
 ) => {
   const includes = [/src\/.*\.m?[jt]sx?$/].concat(extraIncludes);
-  const excludes = [/\.d\.ts$/].concat(extraExcludes);
+  const excludes = [/\.d\.ts$/, /core-js/, /core-js-pure/, /tslib/].concat(extraExcludes);
 
   return createFilter(includes, excludes);
 };

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -287,7 +287,7 @@ export const stringifyObject = (obj: PlainObject) => {
 };
 
 // @ref: It will pass to createScriptFilter function
-export function getIncludeNodeModules(compileDependencies: boolean | Array<RegExp | string>): RegExp[] {
+export function getIncludeNodeModuleScripts(compileDependencies: boolean | Array<RegExp | string>): RegExp[] {
   if (compileDependencies === true || (Array.isArray(compileDependencies) && compileDependencies.length === 0)) {
     return [/node_modules/];
   }
@@ -303,7 +303,7 @@ export function getIncludeNodeModules(compileDependencies: boolean | Array<RegEx
     // will not match:
     // node_modules/abc/node_modules/def/index.js
     // node_modules/def/index.js
-    return [new RegExp(`node_modules/(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')})/(?!node_modules).*`)];
+    return [new RegExp(`node_modules/(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')})/(?!node_modules).*.m?[jt]sx?$`)];
   }
   // default
   return [];

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -287,7 +287,7 @@ export const stringifyObject = (obj: PlainObject) => {
 };
 
 // @ref: It will pass to createScriptFilter function
-export function getIncludeNodeModules(compileDependencies: boolean | RegExp[] | string[]): RegExp[] {
+export function getIncludeNodeModules(compileDependencies: boolean | Array<RegExp | string>): RegExp[] {
   if (compileDependencies === true || (Array.isArray(compileDependencies) && compileDependencies.length === 0)) {
     return [/node_modules/];
   }

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -337,7 +337,7 @@ export const createScriptsFilter = (
   extraExcludes: RegExp[] = [],
 ) => {
   const includes = [/src\/.*\.m?[jt]sx?$/].concat(extraIncludes);
-  const excludes = [/\.d\.ts$/, /core-js/, /core-js-pure/, /tslib/].concat(extraExcludes);
+  const excludes = [/\.d\.ts$/, /core-js/, /core-js-pure/, /tslib/, /@swc\/helpers/, /@babel\/runtime/, /babel-runtime/].concat(extraExcludes);
 
   return createFilter(includes, excludes);
 };

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -287,17 +287,15 @@ export const stringifyObject = (obj: PlainObject) => {
 };
 
 // @ref: It will pass to createScriptFilter function
-export function getExcludeNodeModules(compileDependencies: boolean | RegExp[] | string[]): RegExp[] {
-  if (!compileDependencies) {
-    // not compile deps in node_modules
+export function getIncludeNodeModules(compileDependencies: boolean | RegExp[] | string[]): RegExp[] {
+  if (compileDependencies === true || (Array.isArray(compileDependencies) && compileDependencies.length === 0)) {
     return [/node_modules/];
   }
   if (Array.isArray(compileDependencies) && compileDependencies.length > 0) {
     // compile all deps in node_modules except compileDependencies
-
-    return [new RegExp(`node_modules/(?!(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')}))`)];
+    return [new RegExp(`node_modules/(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')})/(?!node_modules).*`)];
   }
-  // compile all deps in node_modules
+  // default
   return [];
 }
 
@@ -315,6 +313,7 @@ export function formatCnpmDepFilepath(filepath: string) {
 }
 
 /**
+ * default include src/**.m?[jt]sx? but exclude .d.ts file
  *
  * @param extraInclude include other file types
  * @param extraExclude exclude other file types
@@ -322,13 +321,13 @@ export function formatCnpmDepFilepath(filepath: string) {
  * @example exclude node_modules createScriptsFilter([], [/node_modules/])
  */
 export const createScriptsFilter = (
-  extraInclude: RegExp[] = [],
-  extraExclude: RegExp[] = [],
+  extraIncludes: RegExp[] = [],
+  extraExcludes: RegExp[] = [],
 ) => {
-  const exclude = [/\.d\.ts$/].concat(extraExclude);
-  const include = [/\.m?[jt]sx?$/].concat(extraInclude);
+  const includes = [/src\/.*\.m?[jt]sx?$/].concat(extraIncludes);
+  const excludes = [/\.d\.ts$/].concat(extraExcludes);
 
-  return createFilter(include, exclude);
+  return createFilter(includes, excludes);
 };
 
 export const cwd = process.cwd();

--- a/packages/pkg/tests/babelPlugin.test.ts
+++ b/packages/pkg/tests/babelPlugin.test.ts
@@ -34,7 +34,7 @@ describe('transform', () => {
     });
     expect(babelPlugin.name).toBe('ice-pkg:babel');
     // @ts-ignore it's callable
-    const ret = babelPlugin.transform('<div x-if={false}></div>', 'test.tsx');
+    const ret = babelPlugin.transform('<div x-if={false}></div>', 'src/test.tsx');
     expect(cleanCode(ret.code)).toBe(
       cleanCode(`import { createCondition as __create_condition__ } from "babel-runtime-jsx-plus";
     import { jsx as _jsx } from "react/jsx-runtime";
@@ -55,7 +55,7 @@ describe('transform', () => {
     });
     expect(babelPlugin.name).toBe('ice-pkg:babel');
     // @ts-ignore it's callable
-    const ret = babelPlugin.transform('<div x-if={false}></div>', 'test.tsx');
+    const ret = babelPlugin.transform('<div x-if={false}></div>', 'src/test.tsx');
     expect(cleanCode(ret.code)).toBe(
       cleanCode(`import { createCondition as __create_condition__ } from "babel-runtime-jsx-plus";
     __create_condition__([[() => false, () => /*#__PURE__*/React.createElement("div", null)]]);`),

--- a/packages/pkg/tests/formatCnpmDepFilepath.test.ts
+++ b/packages/pkg/tests/formatCnpmDepFilepath.test.ts
@@ -1,0 +1,23 @@
+import { expect, it, describe } from 'vitest';
+import { formatCnpmDepFilepath } from '../src/utils';
+
+describe('formatCnpmDepFilepath function', () => {
+  it('pnpm path', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/.pnpm/classnames@2.3.2/node_modules/classnames/index.js')).toBe('/workspace/node_modules/.pnpm/classnames@2.3.2/node_modules/classnames/index.js');
+  })
+  it('pnpm path with scope', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/.pnpm/@actions+exec@1.1.1/node_modules/@actions/exec/lib/exec.js')).toBe('/workspace/node_modules/.pnpm/@actions+exec@1.1.1/node_modules/@actions/exec/lib/exec.js');
+  })
+  it('cnpm path', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/_idb@7.1.1@idb/build/index.js')).toBe('/workspace/node_modules/idb/build/index.js');
+  })
+  it('cnpm path with npm scope', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/_@swc_helpers@0.5.3@@swc/helpers/esm/_extends.js')).toBe('/workspace/node_modules/@swc/helpers/esm/_extends.js');
+  })
+  it('npm path', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/idb/build/index.js')).toBe('/workspace/node_modules/idb/build/index.js');
+  })
+  it('npm path with npm scope', () => {
+    expect(formatCnpmDepFilepath('/workspace/node_modules/@ice/idb/build/index.js')).toBe('/workspace/node_modules/@ice/idb/build/index.js');
+  })
+})

--- a/website/docs/reference/config.md
+++ b/website/docs/reference/config.md
@@ -443,7 +443,7 @@ export default defineConfig({
 
 #### compileDependencies
 
-+ 类型：`boolean | RegExp[]`
++ 类型：`boolean | RegExp[] | string[]`
 + 默认值：`false`
 
 配置是否编译 node_modules 中的依赖。如果值为 `true`，则 node_modules 中的依赖都会编译；如果值为 false 则都不编译；如果值为数组，则只会编译对应的依赖。
@@ -453,7 +453,7 @@ import { defineConfig } from '@ice/pkg';
 
 export default defineConfig({
   bundle: {
-    compileDependencies: [/antd/],
+    compileDependencies: ['antd'],
   },
 });
 ```


### PR DESCRIPTION
问题 ：当指定编译某个依赖后，会把所有的 node_modules 依赖都编译了

修复上述问题后，并支持传入 compileDependencies 为 `string[]` 类型