### PR TITLE
fix: not exclude deps

### DIFF
--- a/.changeset/sharp-lobsters-pay.md
+++ b/.changeset/sharp-lobsters-pay.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: compile deps that excluded

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -33,9 +33,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version --snapshot canary
-          publish: pnpm install:frozen && pnpm build && pnpm release --tag canary --no-git-tag --snapshot
-          createGithubReleases: false
+          publish: pnpm release:snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.LUHC228_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -33,7 +33,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm release:snapshot
+          version: pnpm changeset version --snapshot canary
+          publish: pnpm install:frozen && pnpm build && pnpm release --tag canary --no-git-tag --snapshot
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.LUHC228_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -289,7 +289,7 @@ export const stringifyObject = (obj: PlainObject) => {
 // @ref: It will pass to createScriptFilter function
 export function getIncludeNodeModuleScripts(compileDependencies: boolean | Array<RegExp | string>): RegExp[] {
   if (compileDependencies === true || (Array.isArray(compileDependencies) && compileDependencies.length === 0)) {
-    return [/node_modules/];
+    return [/node_modules\/.*(?:\.[cm]?[jt]s|[jt]sx)$/];
   }
   if (Array.isArray(compileDependencies) && compileDependencies.length > 0) {
     // compile all deps in node_modules except compileDependencies

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -303,7 +303,7 @@ export function getIncludeNodeModuleScripts(compileDependencies: boolean | Array
     // will not match:
     // node_modules/abc/node_modules/def/index.js
     // node_modules/def/index.js
-    return [new RegExp(`node_modules/(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')})/(?!node_modules).*.(?:[cm]?[jt]s|[jt]sx)$`)];
+    return [new RegExp(`node_modules/(${compileDependencies.map((dep: string | RegExp) => (`${typeof dep === 'string' ? dep : dep.source}`)).join('|')})/(?!node_modules/)[^\\/]+.(?:[cm]?[jt]s|[jt]sx)$`)];
   }
   // default
   return [];


### PR DESCRIPTION
## 问题描述
对于要编译除 node_modules 下某几个包以外的所有 npm 包，用户写下面的代码：

```js
compileDependencies: [/((?!(classnames\/|lodash\/)).)+/]
```

目前的正则匹配实现，如果是有包与包之间的依赖关系，也会把 lodash/classnames 也编译进去：
比如：
- lodash-es
  - lodash 

https://regex101.com/r/antWRA/2