### PR TITLE
fix: add esm @swc/helpers module to cjs module by swc

### DIFF
--- a/.changeset/two-bobcats-sparkle.md
+++ b/.changeset/two-bobcats-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: add esm @swc/helpers module to cjs module by swc

--- a/packages/pkg/src/rollupPlugins/swc.ts
+++ b/packages/pkg/src/rollupPlugins/swc.ts
@@ -90,6 +90,10 @@ async function transformImport(source: string, sourceFilename: string) {
   });
 
   imports.forEach((targetImport) => {
+    if (!targetImport.n) {
+      // If visiting `import.meta.*`, `targetImport.n` will be undefined, that should be ignored.
+      return;
+    }
     if (targetImport.n.startsWith('@swc/helpers')) {
       if (!isESM) {
         // Replace @swc/helpers with cjs path.


### PR DESCRIPTION
## 问题描述

对于在编译 node_modules 依赖的场景下，swc 会使用 esm 的方式 import @swc/helpers 的模块。如果文件原来是 cjs 模块，导致变成了 esm 模块，导致后面的解析有问题。

## 解决

经过 swc 编译的代码，如果判断是 cjs 模块，再 transform import('@swc/helpers/xx') -> require('@swc/helpers/xx')