### PR TITLE
fix: not compile non src entry

### DIFF
--- a/.changeset/lazy-insects-own.md
+++ b/.changeset/lazy-insects-own.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix: not compile non src entry

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -336,7 +336,7 @@ export const createScriptsFilter = (
   extraIncludes: RegExp[] = [],
   extraExcludes: RegExp[] = [],
 ) => {
-  const includes = [/src\/.*\.(?:[cm]?[jt]s|[jt]sx)$/].concat(extraIncludes);
+  const includes = [/^(?!.*node_modules\/).*\.(?:[cm]?[jt]s|[jt]sx)$/].concat(extraIncludes);
   const excludes = [/\.d\.ts$/, /core-js/, /core-js-pure/, /tslib/, /@swc\/helpers/, /@babel\/runtime/, /babel-runtime/].concat(extraExcludes);
 
   return createFilter(includes, excludes);

--- a/packages/pkg/src/utils.ts
+++ b/packages/pkg/src/utils.ts
@@ -336,9 +336,11 @@ export const createScriptsFilter = (
   extraIncludes: RegExp[] = [],
   extraExcludes: RegExp[] = [],
 ) => {
+  // Match non node_modules files. In ICEPKG V2, we only compile src/**.m?[jt]sx? files.
   const includes = [/^(?!.*node_modules\/).*\.(?:[cm]?[jt]s|[jt]sx)$/].concat(extraIncludes);
-  const excludes = [/\.d\.ts$/, /core-js/, /core-js-pure/, /tslib/, /@swc\/helpers/, /@babel\/runtime/, /babel-runtime/].concat(extraExcludes);
 
+  const notCompiledDeps = ['core-js', 'core-js-pure', 'tslib', '@swc/helpers', '@babel/runtime', 'babel-runtime'];
+  const excludes = [/\.d\.ts$/, new RegExp(`node_modules/(${notCompiledDeps.join('|')})`)].concat(extraExcludes);
   return createFilter(includes, excludes);
 };
 

--- a/packages/pkg/tests/createScriptsFilter.test.ts
+++ b/packages/pkg/tests/createScriptsFilter.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'vitest';
+import { createScriptsFilter, getIncludeNodeModuleScripts } from '../src/utils';
+
+test('default createScriptsFilter', async () => {
+  const scriptsFilter = createScriptsFilter();
+  // The path /w is workspace root
+  expect(scriptsFilter('/w/src/a.js')).toBe(true);
+  expect(scriptsFilter('/w/src/a/b.js')).toBe(true);
+  expect(scriptsFilter('/w/cov/a.js')).toBe(true);
+
+  // Windows path
+  expect(scriptsFilter('C:\\w\\src\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\src\\a\\b.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\cov\\a.js')).toBe(true);
+
+  // default exclude node_modules files
+  expect(scriptsFilter('/w/node_modules/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/src/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/@ice/app/a.js')).toBe(false);
+  // default exclude d.ts
+  expect(scriptsFilter('/w/src/a.d.ts')).toBe(false);
+  // default exclude some deps
+  expect(scriptsFilter('/w/node_modules/@babel/runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/babel-runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js-pure/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/tslib/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/@swc/helpers/a.js')).toBe(false);
+})
+
+test('createScriptsFilter with compileDependencies true', async () => {
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModuleScripts(true));
+  // The path /w is workspace root
+
+  // exclude node_modules files
+  expect(scriptsFilter('/w/node_modules/lodash/a.js')).toBe(true);
+  expect(scriptsFilter('/w/node_modules/@ice/app/a.js')).toBe(true);
+
+  // Windows path
+  expect(scriptsFilter('C:\\w\\node_modules\\lodash\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\node_modules\\@ice\\app\\a.js')).toBe(true);
+
+  // default exclude some deps
+  expect(scriptsFilter('/w/node_modules/@babel/runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/babel-runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js-pure/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/tslib/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/@swc/helpers/a.js')).toBe(false);
+
+})
+
+test('createScriptsFilter with some compileDependencies', async () => {
+  const scriptsFilter = createScriptsFilter(getIncludeNodeModuleScripts(['lodash', '@ice/app']));
+
+  // The path /w is workspace root
+
+  // exclude node_modules files
+  expect(scriptsFilter('/w/node_modules/lodash/a.js')).toBe(true);
+  expect(scriptsFilter('/w/node_modules/@ice/app/a.js')).toBe(true);
+  expect(scriptsFilter('/w/node_modules/@ice/runtime/node_modules/lodash/a.js')).toBe(true);
+  expect(scriptsFilter('/w/node_modules/@ice/runtime/node_modules/@ice/app/a.js')).toBe(true);
+  expect(scriptsFilter('/w/node_modules/@ice/app/node_modules/rax-compat/index.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/lodash/node_modules/rax-compat/index.js')).toBe(false);
+  // Windows path
+  expect(scriptsFilter('C:\\w\\node_modules\\lodash\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\node_modules\\@ice\\app\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\node_modules\\@ice\\runtime\\node_modules\\lodash\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\node_modules\\@ice\\runtime\\node_modules\\@ice\\app\\a.js')).toBe(true);
+  expect(scriptsFilter('C:\\w\\node_modules\\@ice\\app\\node_modules\\rax-compat\\index.js')).toBe(false);
+
+  // default exclude some deps
+  expect(scriptsFilter('/w/node_modules/@babel/runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/babel-runtime/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/core-js-pure/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/tslib/a.js')).toBe(false);
+  expect(scriptsFilter('/w/node_modules/@swc/helpers/a.js')).toBe(false);
+})


### PR DESCRIPTION
兼容之前的逻辑，默认编译非 node_modules 下的 js/ts 文件。
> 下个大版本可以只考虑编译 src 下的 js/ts 文件

https://github.com/ice-lab/icepkg/blob/1596db0e3bdd77cb2e527694fdf792d7cae4cec4/packages/pkg/src/utils.ts#L297C2-L297C2