### PR TITLE
fix: dts file write

### DIFF
--- a/.changeset/seven-ravens-know.md
+++ b/.changeset/seven-ravens-know.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+fix dts file write path

--- a/packages/pkg/src/rollupPlugins/dts.ts
+++ b/packages/pkg/src/rollupPlugins/dts.ts
@@ -1,7 +1,6 @@
-import { extname, relative } from 'path';
+import { extname } from 'path';
 import { createFilter } from '@rollup/pluginutils';
 import { dtsCompile, type File } from '../helpers/dts.js';
-import { getTransformEntryDirs } from '../helpers/getTaskIO.js';
 
 import type { Plugin } from 'rollup';
 import type { TaskConfig, UserConfig } from '../types.js';
@@ -22,7 +21,6 @@ interface DtsPluginOptions {
 // dtsPlugin is used to generate declaration file when transforming
 function dtsPlugin({
   rootDir,
-  entry,
   alias,
   generateTypesForJs,
   outputDir,

--- a/packages/pkg/src/rollupPlugins/dts.ts
+++ b/packages/pkg/src/rollupPlugins/dts.ts
@@ -76,21 +76,18 @@ function dtsPlugin({
           return { ...rest };
         });
       }
-      const entries = getTransformEntryDirs(rootDir, entry);
-      entries.forEach((entryItem) => {
-        dtsFiles.forEach((file) => {
-          this.emitFile({
-            type: 'asset',
-            fileName: relative(entryItem, file.dtsPath),
-            source: file.dtsContent,
-          });
-
-          cachedContents[file.filePath] = {
-            ...cachedContents[file.filePath],
-            ...file,
-          };
+      dtsFiles.forEach((file) => {
+        this.emitFile({
+          type: 'asset',
+          fileName: file.dtsPath,
+          source: file.dtsContent,
         });
-      });
+
+        cachedContents[file.filePath] = {
+          ...cachedContents[file.filePath],
+          ...file,
+        };
+      })
 
       updatedIds.forEach((updateId) => { cachedContents[updateId].updated = false; });
     },


### PR DESCRIPTION
修复dts文件写入逻辑

写入路径不需要依赖entires，否则会导致相对路径错误

生成dts时需保证dtsPath为绝对路径，后续直接读取即可

https://github.com/ice-lab/icepkg/blob/c122c90d1eb3df253e8a0a301d75f8e2e8c0adab/packages/pkg/src/tasks/transform.ts#L141 这里保证了入口文件地址为绝对路径


case: 
现在设置了多entry  保留了原始目录 比如
src下有foo bar两个文件夹

最终构建出会保留foo bar两个文件夹 

但是之前的dts文件地址 是遍历了所有entry，然后取的相对路径，  

这时候 foo/a.d.ts 遍历到entry为foo时，为./a.d.ts  当遍历到entry为bar时 相对路径成了../a.d.ts  然后写入的时候 路径就不对了

