### PR TITLE
fix: alias incorrect on windows

### DIFF
--- a/packages/pkg/CHANGELOG.md
+++ b/packages/pkg/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.20
+
+### Patch Changes
+
+- fix: alias path is incorrect on windows system
+
 ## 1.5.19
 
 ### Patch Changes

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/pkg",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "description": "A fast builder for React components, Node modules and web libraries.",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/pkg/src/rollupPlugins/alias.ts
+++ b/packages/pkg/src/rollupPlugins/alias.ts
@@ -69,7 +69,7 @@ export function resolveAliasConfig(alias: Record<string, string>, rootDir: strin
     const target = alias[pattern];
     newAlias[pattern] = target[0] === '.' ?
       // transform alias relative target to relative to the rootDir
-      path.relative(path.dirname(filePath), path.resolve(rootDir, target)) || '.' :
+      path.relative(path.dirname(filePath), path.resolve(rootDir, target)).split(path.sep).join('/') || '.' :
       target;
   });
 


### PR DESCRIPTION
#633 在windows上path返回的路径分隔为\，编译后的路径错误
![image](https://github.com/ice-lab/icepkg/assets/47031061/3d8cee9f-faf0-49e5-8d56-e8f57f0ecfeb)
修改后可以正常通过单测
![image](https://github.com/ice-lab/icepkg/assets/47031061/2dbca3dc-57bd-4563-92ac-1fea9d942fba)
