### PR TITLE
Revert "fix: cjs format should support alias for .d.ts file (#670)"

### DIFF
--- a/.changeset/light-crews-return.md
+++ b/.changeset/light-crews-return.md
@@ -1,0 +1,5 @@
+---
+'@ice/pkg': patch
+---
+
+revert: #670 which is not fully tested for jsx

--- a/packages/pkg/src/helpers/getRollupOptions.ts
+++ b/packages/pkg/src/helpers/getRollupOptions.ts
@@ -83,7 +83,7 @@ export function getRollupOptions(
         }),
       );
     }
-    rollupOptions.plugins.unshift(transformAliasPlugin(rootDir, taskConfig.alias));
+    rollupOptions.plugins.push(transformAliasPlugin(rootDir, taskConfig.alias));
   } else if (taskConfig.type === 'bundle') {
     const [external, globals] = getExternalsAndGlobals(taskConfig, pkg as PkgJson);
     rollupOptions.input = taskConfig.entry;

--- a/packages/pkg/tests/projects/__snapshots__/alias.test.ts.snap
+++ b/packages/pkg/tests/projects/__snapshots__/alias.test.ts.snap
@@ -108,7 +108,7 @@ _export(exports, {
         return _alias.bar;
     }
 });
-var _alias = require(\\"./alias.js\\");
+var _alias = require(\\"@/alias.js\\");
 var foo = 1;
 "
 `;


### PR DESCRIPTION
This reverts commit 3e6f78aed477809551dd989cc05979960512ca9e.

测试发现当 jsx 混用的情况下，先处理 alias 会导致解析出现问题，所以先 revert 掉，等后续多补充些测试 case。